### PR TITLE
Add basic DuckRel wrapper and tests

### DIFF
--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -1,5 +1,6 @@
 """Duck+ public API."""
 
 from .connect import DuckConnection, connect
+from .core import DuckRel
 
-__all__ = ["DuckConnection", "connect"]
+__all__ = ["DuckConnection", "DuckRel", "connect"]

--- a/src/duckplus/core.py
+++ b/src/duckplus/core.py
@@ -1,0 +1,83 @@
+"""Core relational wrappers for Duck+."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import duckdb
+
+from .connect import DuckConnection
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Return an identifier quoted for DuckDB."""
+
+    escaped = identifier.replace("\"", "\"\"")
+    return f'"{escaped}"'
+
+
+@dataclass(frozen=True, slots=True)
+class DuckRel:
+    """Immutable wrapper around a :class:`duckdb.DuckDBPyRelation`."""
+
+    _connection: DuckConnection
+    _relation: duckdb.DuckDBPyRelation
+    _columns: tuple[str, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Ensure columns are cached on instantiation to avoid reliance on DuckDB
+        # defaults later. ``DuckDBPyRelation.columns`` already returns a list of
+        # strings, so it can be stored as an immutable tuple.
+        object.__setattr__(self, "_columns", tuple(self._relation.columns))
+
+    @property
+    def connection(self) -> DuckConnection:
+        """Return the connection associated with the relation."""
+
+        return self._connection
+
+    @property
+    def raw(self) -> duckdb.DuckDBPyRelation:
+        """Expose the underlying :class:`duckdb.DuckDBPyRelation`."""
+
+        return self._relation
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """Return the relation columns preserving their original case."""
+
+        return self._columns
+
+    @property
+    def columns_lower(self) -> tuple[str, ...]:
+        """Return the columns lower-cased in positional order."""
+
+        return tuple(col.lower() for col in self._columns)
+
+    @property
+    def columns_lower_set(self) -> frozenset[str]:
+        """Return a case-insensitive lookup set for the columns."""
+
+        return frozenset(col.lower() for col in self._columns)
+
+    def select(self, *columns: str) -> "DuckRel":
+        """Project the relation onto a subset of columns."""
+
+        if not columns:
+            raise ValueError("select() requires at least one column")
+
+        missing = [name for name in columns if name not in self._columns]
+        if missing:
+            missing_display = ", ".join(sorted(missing))
+            raise KeyError(f"Columns not found: {missing_display}")
+
+        projection = ", ".join(_quote_identifier(name) for name in columns)
+        projected = self._relation.project(projection)
+        return DuckRel(self._connection, projected)
+
+    @classmethod
+    def from_table(cls, connection: DuckConnection, table_name: str) -> "DuckRel":
+        """Create a relation that references an existing DuckDB table."""
+
+        relation = connection.raw.table(table_name)
+        return cls(connection, relation)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,39 @@
+"""Tests for the DuckRel wrapper."""
+
+import pytest
+
+from duckplus import DuckConnection, DuckRel, connect
+
+
+def _prepare_simple_table(conn: DuckConnection) -> None:
+    conn.raw.execute("DROP TABLE IF EXISTS data")
+    conn.raw.execute("CREATE TABLE data (id INTEGER, name TEXT)")
+    conn.raw.execute("INSERT INTO data VALUES (1, 'alpha'), (2, 'beta')")
+
+
+def test_from_table_preserves_columns() -> None:
+    with connect() as conn:
+        _prepare_simple_table(conn)
+        rel = DuckRel.from_table(conn, "data")
+        assert rel.columns == ("id", "name")
+        assert rel.columns_lower == ("id", "name")
+        assert rel.columns_lower_set == {"id", "name"}
+
+
+def test_select_projects_without_mutating_source() -> None:
+    with connect() as conn:
+        _prepare_simple_table(conn)
+        rel = DuckRel.from_table(conn, "data")
+        projected = rel.select("id")
+
+        assert rel.columns == ("id", "name")
+        assert projected.columns == ("id",)
+
+
+def test_select_raises_on_missing_column() -> None:
+    with connect() as conn:
+        _prepare_simple_table(conn)
+        rel = DuckRel.from_table(conn, "data")
+
+        with pytest.raises(KeyError, match="missing"):
+            rel.select("missing")


### PR DESCRIPTION
## Summary
- introduce an immutable DuckRel wrapper that caches column metadata and exposes a select projection helper
- surface DuckRel from the package root for convenience
- cover the new wrapper with tests that verify column metadata and strict missing-column behavior

## Testing
- ⚠️ `uv run pytest` *(fails: offline environment cannot download build requirements)*
- ⚠️ `uv run mypy src/duckplus` *(fails: offline environment cannot download build requirements)*
- ⚠️ `uvx ty src/duckplus` *(fails: offline environment cannot reach PyPI)*

## Design notes
- DuckRel retains immutability by returning a fresh wrapper for select operations while reusing the underlying connection
- Column metadata is cached on initialization so projections avoid DuckDB defaults and stay explicit


------
https://chatgpt.com/codex/tasks/task_e_68e7754941208322b1dcab4a749c31d6