### PR TITLE
Implement foundational utilities for stage 0

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,6 +10,8 @@ This living document captures the staged build-out plan for Duck+. Update it as 
 ## Stage 0 — Foundations & Shared Utilities
 Establish common helpers that every module depends on. Implement these before higher-level features to avoid circular work.
 
+*Status*: ✅ Completed — shared utility helpers and connection extensions are in place.
+
 ### Module: `util`
 *Goals*: provide identifier validation, column casing utilities, and small type helpers that keep `core` lean.
 

--- a/src/duckplus/util.py
+++ b/src/duckplus/util.py
@@ -1,0 +1,127 @@
+"""Shared utility helpers for Duck+."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from enum import Enum
+from os import PathLike, fspath
+from typing import Any
+
+import re
+
+try:  # pragma: no cover - optional dependency
+    import numpy as _np  # type: ignore[import-not-found]
+except ModuleNotFoundError:  # pragma: no cover - numpy isn't a project dependency
+    _np = None
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_QUOTED_IDENTIFIER_RE = re.compile(r'^"(?:[^"]|"")*"$')
+
+
+def ensure_identifier(name: str, *, allow_quoted: bool = False) -> str:
+    """Validate that *name* is a valid DuckDB identifier.
+
+    Parameters
+    ----------
+    name:
+        Identifier to validate.
+    allow_quoted:
+        When ``True`` the identifier may be delimited by double quotes. Inner
+        quotes must be doubled as per SQL rules.
+
+    Returns
+    -------
+    str
+        The original identifier when validation succeeds.
+
+    Raises
+    ------
+    ValueError
+        If the identifier is invalid.
+    """
+
+    if not isinstance(name, str):
+        raise TypeError("Identifier must be a string")
+
+    if _IDENTIFIER_RE.fullmatch(name):
+        return name
+
+    if allow_quoted and _QUOTED_IDENTIFIER_RE.fullmatch(name):
+        # Ensure the identifier is properly quoted from both sides. The regular
+        # expression already enforces doubling of any interior quotes.
+        if name[0] == name[-1] == '"':
+            return name
+
+    raise ValueError(f"Invalid identifier: {name!r}")
+
+
+def normalize_columns(columns: Sequence[str]) -> tuple[list[str], dict[str, int]]:
+    """Return a stable column list along with a case-insensitive lookup map."""
+
+    normalized = list(columns)
+    lookup: dict[str, int] = {}
+
+    for index, column in enumerate(normalized):
+        if not isinstance(column, str):
+            raise TypeError("Column names must be strings")
+
+        key = column.casefold()
+        if key in lookup:
+            raise ValueError(f"Duplicate column name detected: {column!r}")
+        lookup[key] = index
+
+    return normalized, lookup
+
+
+def resolve_columns(
+    requested: Sequence[str],
+    available: Sequence[str],
+    *,
+    missing_ok: bool = False,
+) -> list[str]:
+    """Resolve *requested* column names against *available* ones.
+
+    Resolution is case-insensitive while preserving the stored column casing.
+    When ``missing_ok`` is ``False`` (the default), missing columns raise a
+    :class:`KeyError`.
+    """
+
+    normalized, lookup = normalize_columns(available)
+
+    resolved: list[str] = []
+    missing: list[str] = []
+
+    for column in requested:
+        if not isinstance(column, str):
+            raise TypeError("Requested column names must be strings")
+
+        key = column.casefold()
+        index = lookup.get(key)
+        if index is None:
+            missing.append(column)
+            if missing_ok:
+                continue
+        else:
+            resolved.append(normalized[index])
+
+    if missing and not missing_ok:
+        missing_display = ", ".join(repr(name) for name in missing)
+        raise KeyError(f"Columns not found: {missing_display}")
+
+    return resolved
+
+
+def coerce_scalar(value: Any) -> Any:
+    """Coerce *value* into a DuckDB-friendly scalar."""
+
+    if isinstance(value, Enum):
+        return value.value
+
+    if isinstance(value, PathLike):
+        return fspath(value)
+
+    if _np is not None and isinstance(value, _np.generic):
+        return value.item()
+
+    return value

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+from importlib import import_module
+from typing import Any
+
 import duckplus
+import pytest
+
+connect_mod = import_module("duckplus.connect")
 
 
 def test_connect_executes_simple_query() -> None:
@@ -8,3 +14,42 @@ def test_connect_executes_simple_query() -> None:
         result = conn.raw.execute("SELECT 42").fetchone()
 
     assert result == (42,)
+
+
+def test_connect_applies_configuration(monkeypatch) -> None:
+    captured_config: dict[str, object] = {}
+
+    real_connect = connect_mod.duckdb.connect
+
+    def capture_connect(*args: Any, **kwargs: Any):
+        captured_config.update(kwargs)
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(connect_mod.duckdb, "connect", capture_connect)
+
+    with duckplus.connect(config={"Threads": 1}):
+        pass
+
+    assert captured_config["config"] == {"Threads": "1"}
+
+
+def test_load_extensions_validates_names() -> None:
+    class StubConnection:
+        def __init__(self) -> None:
+            self.loaded: list[str] = []
+
+        @property
+        def raw(self) -> StubConnection:
+            return self
+
+        def load_extension(self, name: str) -> None:
+            self.loaded.append(name)
+
+    conn = StubConnection()
+
+    connect_mod.load_extensions(conn, ["fts5"])
+
+    assert conn.loaded == ["fts5"]
+
+    with pytest.raises(ValueError):
+        connect_mod.load_extensions(conn, ["invalid name"])  # spaces not allowed

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from enum import Enum
+from pathlib import Path
+
+import pytest
+
+from duckplus import util
+
+
+class SampleEnum(Enum):
+    FOO = "foo"
+
+
+def test_ensure_identifier_accepts_simple_names() -> None:
+    assert util.ensure_identifier("valid_name") == "valid_name"
+
+
+def test_ensure_identifier_rejects_invalid_names() -> None:
+    with pytest.raises(ValueError):
+        util.ensure_identifier("123abc")
+
+
+def test_ensure_identifier_allows_quoted_names_when_enabled() -> None:
+    quoted = '"Mixed Case"'
+    assert util.ensure_identifier(quoted, allow_quoted=True) == quoted
+
+    with pytest.raises(ValueError):
+        util.ensure_identifier(quoted)
+
+
+def test_normalize_columns_builds_casefold_lookup() -> None:
+    columns, lookup = util.normalize_columns(["Foo", "Bar"])
+
+    assert columns == ["Foo", "Bar"]
+    assert lookup == {"foo": 0, "bar": 1}
+
+
+def test_normalize_columns_rejects_duplicates_case_insensitive() -> None:
+    with pytest.raises(ValueError):
+        util.normalize_columns(["Foo", "foo"])
+
+
+def test_resolve_columns_handles_case_insensitive_matches() -> None:
+    available = ["Foo", "Bar"]
+    resolved = util.resolve_columns(["foo", "BAR"], available)
+
+    assert resolved == ["Foo", "Bar"]
+
+
+def test_resolve_columns_missing_columns() -> None:
+    with pytest.raises(KeyError):
+        util.resolve_columns(["missing"], ["Foo"])
+
+
+def test_resolve_columns_missing_ok_skips_missing() -> None:
+    result = util.resolve_columns(["missing", "Foo"], ["Foo"], missing_ok=True)
+
+    assert result == ["Foo"]
+
+
+def test_coerce_scalar_handles_path_and_enum() -> None:
+    path = Path("/tmp/example")
+
+    assert util.coerce_scalar(path) == str(path)
+    assert util.coerce_scalar(SampleEnum.FOO) == "foo"


### PR DESCRIPTION
## Summary
- add the shared `util` module with identifier validation, column resolution, and scalar coercion helpers
- extend connection helpers with config validation and explicit extension loading
- cover the new utilities and connection behaviours with unit tests and mark stage 0 as complete in the implementation plan

## Testing
- `uv run pytest`
- `uv run mypy src/duckplus`
- `uvx ty check src/duckplus`

## Design Notes
- identifier and column helpers centralise case-preserving, case-insensitive logic so later stages can reuse consistent semantics
- connection config and extension loading validate identifiers up front to avoid SQL injection while maintaining DuckDB defaults


------
https://chatgpt.com/codex/tasks/task_e_68e7cd0650108322af0ba3656f5948a1