### PR TITLE
Move materialization strategies into dedicated module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,7 +98,7 @@ ipython_config.py
 #   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
-#uv.lock
+uv.lock
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ readme = "README.md"
 license = "MIT"
 authors = [{ name = "Isaac Moore" }]
 requires-python = ">=3.12"
-dependencies = ["duckdb>=1.3.0"]
+dependencies = [
+    "duckdb>=1.3.0",
+    "pyarrow>=16.1",
+]
 
 # Optional extras (keep minimal; ODBC removed — loaded at runtime if needed)
 [project.optional-dependencies]

--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -1,5 +1,20 @@
 """Duck+ public API."""
 
-from .connect import DuckConnection, connect
+from __future__ import annotations
 
-__all__ = ["DuckConnection", "connect"]
+from .connect import DuckConnection, connect
+from .core import DuckRel
+from .materialize import (
+    ArrowMaterializeStrategy,
+    Materialized,
+    ParquetMaterializeStrategy,
+)
+
+__all__ = [
+    "ArrowMaterializeStrategy",
+    "DuckConnection",
+    "DuckRel",
+    "Materialized",
+    "ParquetMaterializeStrategy",
+    "connect",
+]

--- a/src/duckplus/core.py
+++ b/src/duckplus/core.py
@@ -1,0 +1,336 @@
+"""Immutable relational wrapper for Duck+."""
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+import duckdb
+
+from . import util
+from .materialize import (
+    ArrowMaterializeStrategy,
+    MaterializeStrategy,
+    Materialized,
+)
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Return *identifier* quoted for SQL usage."""
+
+    escaped = identifier.replace("\"", "\"\"")
+    return f'"{escaped}"'
+
+
+def _qualify(alias: str, column: str) -> str:
+    """Return a qualified column reference."""
+
+    return f"{alias}.{_quote_identifier(column)}"
+
+
+def _alias(expression: str, alias: str) -> str:
+    """Return a SQL alias expression."""
+
+    return f"{expression} AS {_quote_identifier(alias)}"
+
+
+def _format_projection(columns: Sequence[str], *, alias: str | None = None) -> list[str]:
+    """Return projection expressions for *columns* optionally qualified."""
+
+    qualifier = alias or ""
+    expressions: list[str] = []
+    for column in columns:
+        source = _quote_identifier(column) if not qualifier else _qualify(qualifier, column)
+        expressions.append(_alias(source, column))
+    return expressions
+
+
+def _format_join_condition(pairs: Sequence[tuple[str, str]], *, left_alias: str, right_alias: str) -> str:
+    """Return the join condition for the provided column *pairs*."""
+
+    comparisons = [
+        f"{_qualify(left_alias, left)} = {_qualify(right_alias, right)}" for left, right in pairs
+    ]
+    return " AND ".join(comparisons)
+
+
+def _format_value(value: Any) -> str:
+    """Render *value* as a SQL literal."""
+
+    if value is None:
+        return "NULL"
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (int, float)):
+        return repr(value)
+    if isinstance(value, bytes):
+        return "X'" + value.hex() + "'"
+    if isinstance(value, str):
+        escaped = value.replace("'", "''")
+        return f"'{escaped}'"
+
+    from datetime import date, datetime, time, timedelta
+    from decimal import Decimal
+
+    if isinstance(value, (date, datetime, time)):
+        return f"'{value.isoformat()}'"
+    if isinstance(value, timedelta):
+        total_seconds = value.total_seconds()
+        return repr(total_seconds)
+    if isinstance(value, Decimal):
+        return format(value, "f")
+
+    raise TypeError(f"Unsupported filter parameter type: {type(value)!r}")
+
+
+def _inject_parameters(expression: str, parameters: Sequence[Any]) -> str:
+    """Return *expression* with positional ``?`` placeholders replaced."""
+
+    parts = expression.split("?")
+    placeholder_count = len(parts) - 1
+    if placeholder_count == 0:
+        if parameters:
+            raise ValueError("Number of parameters does not match placeholders")
+        return expression
+
+    if placeholder_count != len(parameters):
+        raise ValueError("Number of parameters does not match placeholders")
+
+    result: list[str] = []
+    for index, segment in enumerate(parts[:-1]):
+        result.append(segment)
+        value = _format_value(parameters[index])
+        result.append(value)
+    result.append(parts[-1])
+    return "".join(result)
+
+
+class DuckRel:
+    """Immutable wrapper around :class:`duckdb.DuckDBPyRelation`."""
+
+    __slots__ = ("_relation", "_columns", "_lookup")
+    _relation: duckdb.DuckDBPyRelation
+    _columns: tuple[str, ...]
+    _lookup: dict[str, int]
+
+    def __setattr__(self, name: str, value: Any) -> None:  # pragma: no cover - defensive
+        if name in self.__slots__ and hasattr(self, name):
+            raise AttributeError("DuckRel is immutable")
+        super().__setattr__(name, value)
+
+    def __init__(
+        self,
+        relation: duckdb.DuckDBPyRelation,
+        *,
+        columns: Sequence[str] | None = None,
+    ) -> None:
+        super().__setattr__("_relation", relation)
+        raw_columns = list(relation.columns if columns is None else columns)
+        normalized, lookup = util.normalize_columns(raw_columns)
+        super().__setattr__("_columns", tuple(normalized))
+        super().__setattr__("_lookup", dict(lookup))
+
+    @property
+    def relation(self) -> duckdb.DuckDBPyRelation:
+        """Return the underlying relation."""
+
+        return self._relation
+
+    @property
+    def columns(self) -> list[str]:
+        """Return the projected column names preserving case."""
+
+        return list(self._columns)
+
+    @property
+    def columns_lower(self) -> list[str]:
+        """Return lower-cased column names in projection order."""
+
+        return [name.casefold() for name in self._columns]
+
+    @property
+    def columns_lower_set(self) -> frozenset[str]:
+        """Return a casefolded set of projected column names."""
+
+        return frozenset(self._lookup)
+
+    def project_columns(self, *columns: str, missing_ok: bool = False) -> DuckRel:
+        """Return a relation containing only the requested *columns*."""
+
+        if not columns:
+            raise ValueError("At least one column must be provided")
+
+        resolved = util.resolve_columns(columns, self._columns, missing_ok=missing_ok)
+        if not resolved:
+            if missing_ok:
+                return self
+            raise KeyError("No columns resolved from projection request")
+        projection = _format_projection(resolved)
+        relation = self._relation.project(", ".join(projection))
+        return type(self)(relation, columns=resolved)
+
+    def project(self, expressions: Mapping[str, str]) -> DuckRel:
+        """Project explicit *expressions* keyed by output column name."""
+
+        if not expressions:
+            raise ValueError("Projection requires at least one expression")
+
+        alias_candidates = list(expressions.keys())
+        aliases, _ = util.normalize_columns(alias_candidates)
+        compiled: list[str] = []
+        for alias in aliases:
+            expression = expressions[alias]
+            if not isinstance(expression, str):
+                raise TypeError("Projection expressions must be strings")
+            compiled.append(_alias(expression, alias))
+        relation = self._relation.project(", ".join(compiled))
+        return type(self)(relation, columns=aliases)
+
+    def filter(self, expression: str, /, *args: Any) -> DuckRel:
+        """Filter the relation using a SQL *expression* with optional parameters."""
+
+        if not isinstance(expression, str):
+            raise TypeError("Filter expression must be a string")
+
+        parameters = [util.coerce_scalar(arg) for arg in args]
+        rendered = _inject_parameters(expression, parameters)
+        relation = self._relation.filter(rendered)
+        return type(self)(relation, columns=self._columns)
+
+    def inner_join(self, other: DuckRel, *, on: Sequence[str] | None = None) -> DuckRel:
+        """Perform an inner join with *other* on shared or explicit keys."""
+
+        return self._join(other, how="inner", on=on)
+
+    def left_join(self, other: DuckRel, *, on: Sequence[str] | None = None) -> DuckRel:
+        """Perform a left join with *other* on shared or explicit keys."""
+
+        return self._join(other, how="left", on=on)
+
+    def semi_join(self, other: DuckRel, *, on: Sequence[str] | None = None) -> DuckRel:
+        """Perform a semi join with *other* on shared or explicit keys."""
+
+        return self._join(other, how="semi", on=on)
+
+    def anti_join(self, other: DuckRel, *, on: Sequence[str] | None = None) -> DuckRel:
+        """Perform an anti join with *other* on shared or explicit keys."""
+
+        return self._join(other, how="anti", on=on)
+
+    def order_by(self, **orders: Literal["asc", "desc", "ASC", "DESC"]) -> DuckRel:
+        """Return a relation ordered by the specified *orders* mapping."""
+
+        if not orders:
+            raise ValueError("At least one column required for ordering")
+
+        order_clauses: list[str] = []
+        for column, direction in orders.items():
+            resolved = util.resolve_columns([column], self._columns)[0]
+            normalized = direction.lower()
+            if normalized not in {"asc", "desc"}:
+                raise ValueError("Ordering direction must be 'asc' or 'desc'")
+            clause = f"{_quote_identifier(resolved)} {normalized.upper()}"
+            order_clauses.append(clause)
+        relation = self._relation.order(", ".join(order_clauses))
+        return type(self)(relation, columns=self._columns)
+
+    def limit(self, count: int) -> DuckRel:
+        """Limit the relation to *count* rows."""
+
+        if not isinstance(count, int):
+            raise TypeError("Limit count must be an integer")
+        if count < 0:
+            raise ValueError("Limit must be non-negative")
+        relation = self._relation.limit(count)
+        return type(self)(relation, columns=self._columns)
+
+    def materialize(
+        self,
+        *,
+        strategy: MaterializeStrategy | None = None,
+        into: duckdb.DuckDBPyConnection | None = None,
+    ) -> Materialized:
+        """Materialize the relation using *strategy* and optional target *into*.
+
+        When *into* is provided the materialized data is registered on the
+        supplied connection and wrapped in a new :class:`DuckRel` instance.
+        The default strategy materializes via Arrow tables and retains the
+        in-memory table.
+        """
+
+        runner = strategy or ArrowMaterializeStrategy()
+        result = runner.materialize(self._relation, self._columns, into=into)
+
+        if into is not None and result.relation is None:
+            raise ValueError("Materialization strategy did not yield a relation for the target connection")
+
+        if into is None and result.table is None and result.path is None:
+            raise ValueError("Materialization strategy did not produce any artefact")
+
+        wrapped: DuckRel | None = None
+        if result.relation is not None:
+            resolved_columns = tuple(result.columns) if result.columns is not None else self._columns
+            wrapped = type(self)(result.relation, columns=resolved_columns)
+
+        return Materialized(
+            table=result.table,
+            relation=wrapped,
+            path=result.path,
+        )
+
+    # Internal helpers -------------------------------------------------
+
+    def _join(
+        self,
+        other: DuckRel,
+        *,
+        how: str,
+        on: Sequence[str] | None,
+    ) -> DuckRel:
+        if on is None:
+            pairs = self._resolve_shared_keys(other)
+            if not pairs:
+                raise ValueError("No shared columns to join on")
+        else:
+            pairs = self._resolve_explicit_keys(other, on)
+
+        left_alias = self._relation.set_alias("l")
+        right_alias = other._relation.set_alias("r")
+        condition = _format_join_condition(pairs, left_alias="l", right_alias="r")
+        joined = left_alias.join(right_alias, condition, how=how)
+
+        if how in {"semi", "anti"}:
+            projection = _format_projection(self._columns, alias="l")
+            relation = joined.project(", ".join(projection))
+            return type(self)(relation, columns=self._columns)
+
+        right_key_set = {right.casefold() for _, right in pairs}
+        right_columns = [
+            column for column in other._columns if column.casefold() not in right_key_set
+        ]
+        projection = _format_projection(self._columns, alias="l")
+        projection.extend(_format_projection(right_columns, alias="r"))
+        relation = joined.project(", ".join(projection))
+        merged_columns = list(self._columns) + right_columns
+        return type(self)(relation, columns=merged_columns)
+
+    def _resolve_shared_keys(self, other: DuckRel) -> list[tuple[str, str]]:
+        pairs: list[tuple[str, str]] = []
+        for column in self._columns:
+            other_index = other._lookup.get(column.casefold())
+            if other_index is not None:
+                pairs.append((column, other._columns[other_index]))
+        return pairs
+
+    def _resolve_explicit_keys(
+        self, other: DuckRel, requested: Sequence[str]
+    ) -> list[tuple[str, str]]:
+        left_columns = util.resolve_columns(requested, self._columns)
+        pairs: list[tuple[str, str]] = []
+        for left in left_columns:
+            right_index = other._lookup.get(left.casefold())
+            if right_index is None:
+                raise KeyError(f"Column {left!r} not found in right relation")
+            pairs.append((left, other._columns[right_index]))
+        return pairs
+
+

--- a/src/duckplus/materialize.py
+++ b/src/duckplus/materialize.py
@@ -1,0 +1,146 @@
+"""Materialization strategies and result helpers for DuckRel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol, Sequence, TYPE_CHECKING
+
+import duckdb
+import pyarrow as pa  # type: ignore[import-untyped]
+import pyarrow.parquet as pq  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from .core import DuckRel
+
+
+@dataclass(slots=True)
+class MaterializeArtifacts:
+    """Internal container produced by :class:`MaterializeStrategy` objects."""
+
+    table: pa.Table | None = None
+    relation: duckdb.DuckDBPyRelation | None = None
+    columns: Sequence[str] | None = None
+    path: Path | None = None
+
+
+class MaterializeStrategy(Protocol):
+    """Strategy used by :meth:`duckplus.core.DuckRel.materialize`."""
+
+    def materialize(
+        self,
+        relation: duckdb.DuckDBPyRelation,
+        columns: Sequence[str],
+        *,
+        into: duckdb.DuckDBPyConnection | None,
+    ) -> MaterializeArtifacts:
+        """Return the materialization artefacts for *relation*."""
+
+
+class ArrowMaterializeStrategy:
+    """Materialize relations via Arrow tables."""
+
+    __slots__ = ("_retain_table",)
+
+    def __init__(self, *, retain_table: bool = True) -> None:
+        self._retain_table = retain_table
+
+    def materialize(
+        self,
+        relation: duckdb.DuckDBPyRelation,
+        columns: Sequence[str],
+        *,
+        into: duckdb.DuckDBPyConnection | None,
+    ) -> MaterializeArtifacts:
+        table = relation.to_arrow_table()
+        if into is None:
+            return MaterializeArtifacts(table=table)
+        target = into.from_arrow(table)
+        stored = table if self._retain_table else None
+        return MaterializeArtifacts(
+            table=stored,
+            relation=target,
+            columns=columns,
+        )
+
+
+class ParquetMaterializeStrategy:
+    """Materialize relations through Parquet files."""
+
+    __slots__ = ("_path", "_cleanup", "_suffix")
+
+    def __init__(
+        self,
+        path: Path | None = None,
+        *,
+        cleanup: bool = False,
+        suffix: str = ".parquet",
+    ) -> None:
+        self._path = path
+        self._cleanup = cleanup
+        self._suffix = suffix
+
+    def materialize(
+        self,
+        relation: duckdb.DuckDBPyRelation,
+        columns: Sequence[str],
+        *,
+        into: duckdb.DuckDBPyConnection | None,
+    ) -> MaterializeArtifacts:
+        import os
+        import tempfile
+
+        created_path = False
+        file_path = self._path
+        if file_path is None:
+            handle, name = tempfile.mkstemp(prefix="duckplus_materialized_", suffix=self._suffix)
+            os.close(handle)
+            file_path = Path(name)
+            created_path = True
+
+        relation.to_parquet(str(file_path))
+        table = pq.read_table(file_path)
+        target = into.read_parquet(str(file_path)) if into is not None else None
+
+        final_path: Path | None = file_path
+        if self._cleanup and created_path:
+            file_path.unlink(missing_ok=True)
+            final_path = None
+
+        return MaterializeArtifacts(
+            table=table,
+            relation=target,
+            columns=columns,
+            path=final_path,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class Materialized:
+    """Result of :meth:`duckplus.core.DuckRel.materialize`."""
+
+    table: pa.Table | None
+    relation: DuckRel | None
+    path: Path | None
+
+    def require_table(self) -> pa.Table:
+        """Return the Arrow table or raise if unavailable."""
+
+        if self.table is None:
+            raise ValueError("Materialization strategy did not produce an Arrow table")
+        return self.table
+
+    def require_relation(self) -> DuckRel:
+        """Return the materialized :class:`DuckRel` or raise if unavailable."""
+
+        if self.relation is None:
+            raise ValueError("Materialization strategy did not produce a relation")
+        return self.relation
+
+
+__all__ = [
+    "MaterializeStrategy",
+    "ArrowMaterializeStrategy",
+    "ParquetMaterializeStrategy",
+    "Materialized",
+]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import duckdb
+import pyarrow as pa
+import pytest
+
+from pathlib import Path
+
+from duckplus.core import DuckRel
+from duckplus.materialize import ParquetMaterializeStrategy
+
+
+def table_rows(table: pa.Table) -> list[tuple[object, ...]]:
+    columns = [table.column(i).to_pylist() for i in range(table.num_columns)]
+    if not columns:
+        return [tuple() for _ in range(table.num_rows)]
+    return list(zip(*columns, strict=True))
+
+
+@pytest.fixture()
+def connection() -> duckdb.DuckDBPyConnection:
+    conn = duckdb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture()
+def sample_rel(connection: duckdb.DuckDBPyConnection) -> DuckRel:
+    base = connection.sql(
+        """
+        SELECT *
+        FROM (VALUES
+            (1, 'Alpha', 10),
+            (2, 'Beta', 5),
+            (3, 'Gamma', 8)
+        ) AS t(id, Name, score)
+        """
+    )
+    return DuckRel(base)
+
+
+def test_columns_metadata_preserves_case(sample_rel: DuckRel) -> None:
+    assert sample_rel.columns == ["id", "Name", "score"]
+    assert sample_rel.columns_lower == ["id", "name", "score"]
+    assert sample_rel.columns_lower_set == frozenset({"id", "name", "score"})
+
+
+def test_project_columns_case_insensitive(sample_rel: DuckRel) -> None:
+    selected = sample_rel.project_columns("name", "ID")
+    assert selected.columns == ["Name", "id"]
+    assert table_rows(selected.materialize().require_table()) == [
+        ("Alpha", 1),
+        ("Beta", 2),
+        ("Gamma", 3),
+    ]
+
+
+def test_project_columns_missing_ok_returns_original(sample_rel: DuckRel) -> None:
+    rel = sample_rel.project_columns("missing", missing_ok=True)
+    assert rel is sample_rel
+
+
+def test_project_allows_computed_columns(sample_rel: DuckRel) -> None:
+    projected = sample_rel.project({"id": '"id"', "label": 'upper("Name")', "score": '"score"'})
+    assert projected.columns == ["id", "label", "score"]
+    assert table_rows(projected.materialize().require_table())[0] == (1, "ALPHA", 10)
+
+
+def test_filter_supports_parameters(sample_rel: DuckRel) -> None:
+    filtered = sample_rel.filter('"id" = ? AND "Name" = ?', 2, "Beta")
+    assert table_rows(filtered.materialize().require_table()) == [(2, "Beta", 5)]
+
+
+@pytest.mark.parametrize(
+    "values, error",
+    [
+        ((), ValueError),
+        ((1,), ValueError),
+    ],
+)
+def test_filter_parameter_validation(values: tuple[object, ...], error: type[Exception], sample_rel: DuckRel) -> None:
+    with pytest.raises(error):
+        sample_rel.filter('"id" = ? AND "Name" = ?', *values)
+
+
+def test_inner_join_defaults_to_shared_keys(connection: duckdb.DuckDBPyConnection) -> None:
+    left = DuckRel(
+        connection.sql(
+            """
+            SELECT *
+            FROM (VALUES
+                (1, 'L1'),
+                (2, 'L2')
+            ) AS t(id, left_val)
+            """
+        )
+    )
+    right = DuckRel(
+        connection.sql(
+            """
+            SELECT *
+            FROM (VALUES
+                (1, 'R1'),
+                (3, 'R3')
+            ) AS t(ID, right_val)
+            """
+        )
+    )
+
+    joined = left.inner_join(right)
+    assert joined.columns == ["id", "left_val", "right_val"]
+    assert table_rows(joined.materialize().require_table()) == [(1, "L1", "R1")]
+
+
+def test_left_join_with_missing_rows(connection: duckdb.DuckDBPyConnection) -> None:
+    left = DuckRel(connection.sql("SELECT * FROM (VALUES (1, 'L1'), (2, 'L2')) AS t(id, left_val)"))
+    right = DuckRel(connection.sql("SELECT * FROM (VALUES (1, 'R1')) AS t(id, right_val)"))
+
+    joined = left.left_join(right)
+    assert table_rows(joined.materialize().require_table()) == [(1, "L1", "R1"), (2, "L2", None)]
+
+
+def test_join_missing_shared_keys_raises(connection: duckdb.DuckDBPyConnection) -> None:
+    left = DuckRel(connection.sql("SELECT 1 AS a"))
+    right = DuckRel(connection.sql("SELECT 1 AS b"))
+    with pytest.raises(ValueError):
+        left.inner_join(right)
+
+
+def test_semi_and_anti_join(connection: duckdb.DuckDBPyConnection) -> None:
+    left = DuckRel(connection.sql("SELECT * FROM (VALUES (1), (2), (3)) AS t(id)"))
+    right = DuckRel(connection.sql("SELECT * FROM (VALUES (2), (3)) AS t(id)"))
+
+    semi = left.semi_join(right)
+    anti = left.anti_join(right)
+
+    assert table_rows(semi.materialize().require_table()) == [(2,), (3,)]
+    assert table_rows(anti.materialize().require_table()) == [(1,)]
+
+
+def test_order_by_and_limit(sample_rel: DuckRel) -> None:
+    ordered = sample_rel.order_by(score="desc").limit(2)
+    assert table_rows(ordered.materialize().require_table()) == [(1, "Alpha", 10), (3, "Gamma", 8)]
+
+
+def test_materialize_returns_arrow_table(sample_rel: DuckRel) -> None:
+    result = sample_rel.materialize()
+    table = result.require_table()
+    assert isinstance(table, pa.Table)
+    assert result.relation is None
+    assert result.path is None
+
+
+def test_materialize_into_new_connection(sample_rel: DuckRel) -> None:
+    other = duckdb.connect()
+    try:
+        result = sample_rel.materialize(into=other)
+        relation = result.require_relation()
+        rows = table_rows(relation.materialize().require_table())
+        assert rows == table_rows(sample_rel.materialize().require_table())
+    finally:
+        other.close()
+
+
+def test_materialize_parquet_strategy(sample_rel: DuckRel, tmp_path: Path) -> None:
+    path = tmp_path / "dataset.parquet"
+    strategy = ParquetMaterializeStrategy(path)
+    result = sample_rel.materialize(strategy=strategy)
+    table = result.require_table()
+    assert result.path == path
+    assert path.exists()
+    other = duckdb.connect()
+    try:
+        moved = sample_rel.materialize(strategy=strategy, into=other)
+        relation = moved.require_relation()
+        assert table_rows(relation.materialize().require_table()) == table_rows(table)
+    finally:
+        other.close()


### PR DESCRIPTION
## Summary
- extract the materialization protocol, strategies, and result wrapper into a new `materialize` module and update `DuckRel.materialize` to depend on it
- refresh the public exports, core tests, and implementation plan to reflect the relocated strategies and ignore `uv.lock`

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68e83834a7488322875d177b409523a0