### PR TITLE
Add exploratory DuckRel integration tests

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -70,6 +70,10 @@ Implementation sequence:
 ## Stage 2 — Table Mutations
 Introduce stateful operations only after `DuckRel` is stable.
 
+*Status*: ✅ Completed — `DuckTable` now wraps mutation helpers with append,
+antijoin, and continuous-ID insert strategies, each covered by unit tests in
+`tests/test_table.py`.
+
 ### Module: `table`
 *Goals*: wrap `DuckRel` targets with mutation helpers that respect insert semantics.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dev-dependencies = [
 [tool.pytest.ini_options]
 addopts = "-q"
 python_files = "test_*.py"
+markers = [
+    "mutable_with_approval: Exploratory integration coverage that maintainers may revise as APIs evolve",
+]
 
 [tool.mypy]
 python_version = "3.12"

--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .connect import DuckConnection, connect
 from .core import DuckRel
+from .table import DuckTable
 from .materialize import (
     ArrowMaterializeStrategy,
     Materialized,
@@ -14,6 +15,7 @@ __all__ = [
     "ArrowMaterializeStrategy",
     "DuckConnection",
     "DuckRel",
+    "DuckTable",
     "Materialized",
     "ParquetMaterializeStrategy",
     "connect",

--- a/src/duckplus/table.py
+++ b/src/duckplus/table.py
@@ -1,0 +1,150 @@
+"""Mutable table wrapper for Duck+."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Optional, Tuple
+
+from . import util
+from .connect import DuckConnection
+from .core import DuckRel
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Return *identifier* quoted for SQL usage."""
+
+    escaped = identifier.replace('"', '""')
+    return f'"{escaped}"'
+
+
+def _normalize_table_reference(name: str) -> str:
+    """Return a sanitized table reference supporting dotted paths."""
+
+    if not isinstance(name, str):
+        raise TypeError("Table name must be a string")
+
+    parts: list[str] = []
+    current: list[str] = []
+    in_quotes = False
+    index = 0
+    length = len(name)
+    while index < length:
+        char = name[index]
+        if char == '"':
+            current.append(char)
+            if in_quotes and index + 1 < length and name[index + 1] == '"':
+                current.append('"')
+                index += 2
+                continue
+            in_quotes = not in_quotes
+            index += 1
+            continue
+        if char == "." and not in_quotes:
+            part = "".join(current).strip()
+            if not part:
+                raise ValueError("Empty identifier segment in table name")
+            util.ensure_identifier(part, allow_quoted=True)
+            parts.append(part)
+            current = []
+            index += 1
+            continue
+        current.append(char)
+        index += 1
+
+    if in_quotes:
+        raise ValueError("Unterminated quoted identifier in table name")
+
+    part = "".join(current).strip()
+    if not part:
+        raise ValueError("Empty identifier segment in table name")
+    util.ensure_identifier(part, allow_quoted=True)
+    parts.append(part)
+
+    return ".".join(parts)
+
+
+class DuckTable:
+    """Mutable wrapper around a DuckDB table."""
+
+    def __init__(self, connection: DuckConnection, name: str) -> None:
+        self._connection = connection
+        self._name = _normalize_table_reference(name)
+
+    @property
+    def name(self) -> str:
+        """Return the normalized table name."""
+
+        return self._name
+
+    def append(self, rel: DuckRel, *, by_name: bool = True) -> None:
+        """Append rows from *rel* into the table."""
+
+        table_columns = self._table_columns()
+        relation = rel
+
+        if by_name:
+            ordered = util.resolve_columns(table_columns, rel.columns)
+            relation = rel.project_columns(*ordered)
+        else:
+            if len(rel.columns) != len(table_columns):
+                raise ValueError("Relation column count must match table when by_name is False")
+
+        relation.relation.insert_into(self._name)
+
+    def insert_antijoin(self, rel: DuckRel, *, keys: Sequence[str]) -> int:
+        """Insert rows from *rel* missing in the table based on *keys*."""
+
+        if not keys:
+            raise ValueError("At least one key column is required")
+
+        table_columns = self._table_columns()
+        resolved_keys = util.resolve_columns(keys, table_columns)
+
+        table_rel = DuckRel(self._connection.raw.table(self._name))
+        existing = table_rel.project_columns(*resolved_keys)
+        filtered = rel.anti_join(existing, on=resolved_keys)
+
+        count_relation = filtered.relation.aggregate("count(*)")
+        result: Optional[Tuple[Any, ...]] = count_relation.fetchone()
+        count = 0
+        if result is not None:
+            first = result[0]
+            count = int(first or 0)
+
+        if count > 0:
+            self.append(filtered)
+
+        return count
+
+    def insert_by_continuous_id(
+        self,
+        rel: DuckRel,
+        *,
+        id_column: str,
+        inclusive: bool = False,
+    ) -> int:
+        """Insert rows from *rel* with IDs beyond the table's current maximum."""
+
+        table_columns = self._table_columns()
+        resolved_id = util.resolve_columns([id_column], table_columns)[0]
+
+        raw = self._connection.raw
+        query = f"SELECT max({_quote_identifier(resolved_id)}) FROM {self._name}"
+        max_row: Optional[Tuple[Any, ...]] = raw.execute(query).fetchone()
+        current_max = None if max_row is None else max_row[0]
+
+        if current_max is None:
+            candidate = rel
+        else:
+            rel_id = util.resolve_columns([resolved_id], rel.columns)[0]
+            op = ">=" if inclusive else ">"
+            candidate = rel.filter(f"{_quote_identifier(rel_id)} {op} ?", current_max)
+
+        return self.insert_antijoin(candidate, keys=[resolved_id])
+
+    # Internal helpers -------------------------------------------------
+
+    def _table_columns(self) -> list[str]:
+        relation = self._connection.raw.table(self._name)
+        return list(relation.columns)
+

--- a/tests/test_relation_integration.py
+++ b/tests/test_relation_integration.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+"""Integration-style exploratory tests exercising DuckRel flows."""
+
+from datetime import datetime
+
+import pytest
+
+from duckplus import (
+    ArrowMaterializeStrategy,
+    DuckConnection,
+    DuckRel,
+    ParquetMaterializeStrategy,
+    connect,
+)
+
+import pyarrow as pa
+
+
+pytestmark = pytest.mark.mutable_with_approval
+
+
+@pytest.fixture()
+def connection() -> DuckConnection:
+    with connect() as conn:
+        yield conn
+
+
+def table_rows(table: pa.Table) -> list[tuple[object, ...]]:
+    """Return ordered row tuples from an Arrow table."""
+
+    columns = [table.column(i).to_pylist() for i in range(table.num_columns)]
+    if not columns:
+        return [tuple() for _ in range(table.num_rows)]
+    return list(zip(*columns, strict=True))
+
+
+def test_exploratory_feature_engineering_pipeline(connection: DuckConnection) -> None:
+    """Integration-style DuckRel feature engineering flow covering joins and projections."""
+
+    events = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (501, 2001, 'viewed', 'web', TIMESTAMP '2024-01-10 08:00:00'),
+                    (502, 2002, 'viewed', 'email', TIMESTAMP '2024-01-11 09:15:00'),
+                    (503, 2003, 'clicked', 'web', TIMESTAMP '2024-01-13 10:45:00'),
+                    (504, 2004, 'purchased', 'retail', TIMESTAMP '2024-01-18 12:30:00')
+            ) AS events(event_id, user_id, event_type, channel, occurred_at)
+            """
+        )
+    )
+
+    users = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (2001, 'active', TIMESTAMP '2023-12-20 10:00:00', 'NA'),
+                    (2002, 'inactive', TIMESTAMP '2023-12-01 11:30:00', 'NA'),
+                    (2003, 'active', TIMESTAMP '2023-11-05 15:15:00', 'EMEA'),
+                    (2004, 'active', TIMESTAMP '2023-10-01 09:30:00', 'LATAM')
+            ) AS profiles(user_id, status, first_purchase_at, region)
+            """
+        )
+    )
+
+    loyalty = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (2001, 'gold'),
+                    (2003, 'silver'),
+                    (2004, 'platinum'),
+                    (2005, 'gold')
+            ) AS loyalty(user_id, tier)
+            """
+        )
+    )
+
+    channel_map = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    ('web', 'Web App'),
+                    ('email', 'Lifecycle Email'),
+                    ('retail', 'Retail Store')
+            ) AS mapping(channel, source_name)
+            """
+        )
+    )
+
+    eligible_loyalty = loyalty.filter('"tier" IN (?, ?)', "gold", "platinum").project(
+        {
+            "user_id": '"user_id"',
+            "loyalty_tier": 'upper("tier")',
+        }
+    )
+
+    active_profiles = users.project(
+        {
+            "user_id": '"user_id"',
+            "status": 'upper("status")',
+            "first_purchase_at": '"first_purchase_at"',
+            "region": '"region"',
+        }
+    ).filter('"status" = ?', "ACTIVE")
+
+    curated = (
+        events
+        .semi_join(eligible_loyalty, on=["user_id"])
+        .inner_join(eligible_loyalty, on=["user_id"])
+        .inner_join(active_profiles, on=["user_id"])
+        .inner_join(channel_map, on=["channel"])
+        .project(
+            {
+                "user_id": '"user_id"',
+                "event_id": '"event_id"',
+                "loyalty_tier": 'upper("loyalty_tier")',
+                "engagement_label": "upper(\"event_type\") || ' - ' || \"source_name\"",
+                "tenure_days": "datediff('day', \"first_purchase_at\", \"occurred_at\")",
+                "region": '"region"',
+                "occurred_at": '"occurred_at"',
+            }
+        )
+        .order_by(occurred_at="asc", event_id="desc")
+        .limit(5)
+    )
+
+    materialized = curated.materialize(strategy=ParquetMaterializeStrategy(cleanup=True))
+    table = materialized.require_table()
+
+    assert materialized.path is None
+    assert table.schema.names == [
+        "user_id",
+        "event_id",
+        "loyalty_tier",
+        "engagement_label",
+        "tenure_days",
+        "region",
+        "occurred_at",
+    ]
+
+    assert table_rows(table) == [
+        (
+            2001,
+            501,
+            "GOLD",
+            "VIEWED - Web App",
+            21,
+            "NA",
+            datetime(2024, 1, 10, 8, 0, 0),
+        ),
+        (
+            2004,
+            504,
+            "PLATINUM",
+            "PURCHASED - Retail Store",
+            109,
+            "LATAM",
+            datetime(2024, 1, 18, 12, 30, 0),
+        ),
+    ]
+
+
+def test_exploratory_backlog_snapshot(connection: DuckConnection) -> None:
+    """Integration-style DuckRel snapshot building flow covering anti-joins and materialize targets."""
+
+    orders = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (9001, 'ACME', 'open', 120.50, DATE '2024-01-05'),
+                    (9002, 'ZENITH', 'closed', 200.00, DATE '2024-01-02'),
+                    (9003, 'ACME', 'backorder', 320.00, DATE '2024-01-07'),
+                    (9004, 'OMEGA', 'open', 75.00, DATE '2024-01-09'),
+                    (9005, 'LUMEN', 'open', 60.00, DATE '2024-01-11')
+            ) AS orders(order_id, account, status, amount, placed_at)
+            """
+        )
+    )
+
+    shipments = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (9001, DATE '2024-01-06')
+            ) AS shipments(order_id, shipped_at)
+            """
+        )
+    )
+
+    risk = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    ('ACME', 'high'),
+                    ('OMEGA', 'medium')
+            ) AS risk(account, risk_level)
+            """
+        )
+    )
+
+    risk_profiles = risk.project(
+        {
+            "account": '"account"',
+            "risk_level": 'upper("risk_level")',
+        }
+    )
+
+    backlog = (
+        orders
+        .filter('"status" IN (?, ?)', "open", "backorder")
+        .anti_join(shipments, on=["order_id"])
+        .left_join(risk_profiles, on=["account"])
+    )
+
+    prioritized = backlog.project(
+        {
+            "order_id": '"order_id"',
+            "account": '"account"',
+            "status": '"status"',
+            "amount": 'cast("amount" AS DOUBLE)',
+            "placed_at": 'cast("placed_at" AS TIMESTAMP)',
+            "risk_level": "coalesce(upper(\"risk_level\"), 'LOW')",
+            "priority_bucket": "CASE\n                WHEN coalesce(upper(\"risk_level\"), 'LOW') = 'HIGH' THEN 'Expedite'\n                WHEN \"amount\" >= 300 THEN 'Review'\n                WHEN coalesce(upper(\"risk_level\"), 'LOW') = 'MEDIUM' THEN 'Monitor'\n                ELSE 'Observe'\n            END",
+            "priority_score": "CASE\n                WHEN coalesce(upper(\"risk_level\"), 'LOW') = 'HIGH' THEN 1\n                WHEN \"amount\" >= 300 THEN 2\n                WHEN coalesce(upper(\"risk_level\"), 'LOW') = 'MEDIUM' THEN 3\n                ELSE 4\n            END",
+        }
+    )
+
+    ordered = prioritized.order_by(priority_score="asc", amount="desc")
+    limited = ordered.limit(2)
+    final_snapshot = limited.project_columns(
+        "order_id",
+        "account",
+        "risk_level",
+        "status",
+        "amount",
+        "placed_at",
+        "priority_bucket",
+    )
+
+    with connect() as snapshot:
+        materialized = final_snapshot.materialize(
+            strategy=ArrowMaterializeStrategy(retain_table=False),
+            into=snapshot.raw,
+        )
+
+        assert materialized.table is None
+        rel_snapshot = materialized.require_relation()
+        assert rel_snapshot.columns == [
+            "order_id",
+            "account",
+            "risk_level",
+            "status",
+            "amount",
+            "placed_at",
+            "priority_bucket",
+        ]
+
+        snapshot_table = rel_snapshot.materialize().require_table()
+
+    assert table_rows(snapshot_table) == [
+        (
+            9003,
+            "ACME",
+            "HIGH",
+            "backorder",
+            320.0,
+            datetime(2024, 1, 7, 0, 0),
+            "Expedite",
+        ),
+        (
+            9004,
+            "OMEGA",
+            "MEDIUM",
+            "open",
+            75.0,
+            datetime(2024, 1, 9, 0, 0),
+            "Monitor",
+        ),
+    ]

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from duckplus import DuckConnection, DuckRel, DuckTable, connect
+
+
+@pytest.fixture()
+def connection() -> DuckConnection:
+    with connect() as conn:
+        yield conn
+
+
+def materialized_rows(conn: DuckConnection, table: str) -> list[tuple[object, ...]]:
+    rows = conn.raw.execute(f"SELECT * FROM {table} ORDER BY 1").fetchall()
+    return [tuple(row) for row in rows]
+
+
+def test_append_aligns_columns_by_name(connection: DuckConnection) -> None:
+    connection.raw.execute("CREATE TABLE target(id INTEGER, value VARCHAR)")
+    rel = DuckRel(
+        connection.raw.sql(
+            "SELECT value, id FROM (VALUES ('a', 1), ('b', 2)) AS t(value, id)"
+        )
+    )
+    table = DuckTable(connection, "target")
+    table.append(rel)
+
+    assert materialized_rows(connection, "target") == [(1, "a"), (2, "b")]
+
+
+def test_append_by_position_requires_matching_counts(connection: DuckConnection) -> None:
+    connection.raw.execute("CREATE TABLE numbers(id INTEGER)")
+    rel = DuckRel(connection.raw.sql("SELECT 1 AS value, 2 AS extra"))
+    table = DuckTable(connection, "numbers")
+    with pytest.raises(ValueError):
+        table.append(rel, by_name=False)
+
+
+def test_insert_antijoin_inserts_missing_rows(connection: DuckConnection) -> None:
+    connection.raw.execute("CREATE TABLE items(id INTEGER, label VARCHAR)")
+    connection.raw.execute("INSERT INTO items VALUES (1, 'one'), (2, 'two')")
+
+    rel = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES (2, 'two'), (3, 'three'), (4, 'four')
+            ) AS t(id, label)
+            """
+        )
+    )
+    table = DuckTable(connection, "items")
+    inserted = table.insert_antijoin(rel, keys=["id"])
+
+    assert inserted == 2
+    assert materialized_rows(connection, "items") == [
+        (1, "one"),
+        (2, "two"),
+        (3, "three"),
+        (4, "four"),
+    ]
+
+
+def test_insert_by_continuous_id_respects_threshold(connection: DuckConnection) -> None:
+    connection.raw.execute("CREATE TABLE events(id INTEGER, payload VARCHAR)")
+    connection.raw.execute("INSERT INTO events VALUES (1, 'a'), (2, 'b'), (3, 'c')")
+
+    rel = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e')
+            ) AS t(id, payload)
+            """
+        )
+    )
+    table = DuckTable(connection, "events")
+    inserted = table.insert_by_continuous_id(rel, id_column="id")
+    assert inserted == 2
+
+    rel2 = DuckRel(
+        connection.raw.sql(
+            "SELECT * FROM (VALUES (5, 'e'), (6, 'f')) AS t(id, payload)"
+        )
+    )
+    inserted_again = table.insert_by_continuous_id(rel2, id_column="id", inclusive=True)
+    assert inserted_again == 1
+
+    assert materialized_rows(connection, "events") == [
+        (1, "a"),
+        (2, "b"),
+        (3, "c"),
+        (4, "d"),
+        (5, "e"),
+        (6, "f"),
+    ]

--- a/tests/test_table_integration.py
+++ b/tests/test_table_integration.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+"""Integration-style exploratory tests exercising DuckTable flows."""
+
+from datetime import datetime
+
+import pytest
+
+from duckplus import DuckConnection, DuckRel, DuckTable, connect
+
+
+pytestmark = pytest.mark.mutable_with_approval
+
+
+@pytest.fixture()
+def connection() -> DuckConnection:
+    with connect() as conn:
+        yield conn
+
+
+def fetch_table_rows(conn: DuckConnection, table: str) -> list[tuple[object, ...]]:
+    """Return ordered rows from *table* for assertion-friendly comparisons."""
+
+    rows = conn.raw.execute(f"SELECT * FROM {table} ORDER BY 1").fetchall()
+    return [tuple(row) for row in rows]
+
+
+
+def test_exploratory_dimension_ingestion_flow(connection: DuckConnection) -> None:
+    """Integration-style dimension pipeline covering append and anti-join."""
+
+    # Exploratory integration context (mutable with approval): the scenario
+    # intentionally mirrors a warehouse landing step followed by a deduplicated
+    # incremental feed so maintainers can evolve the flow if future helpers are
+    # introduced.
+
+    # An integration-style scenario that simulates a dimension table pipeline.
+    #
+    # The test loads an initial landing relation containing messy casing and
+    # derived segment data, normalizes it through DuckRel transformations, and
+    # appends it into the warehouse dimension. It then stages another relation
+    # that mixes duplicate and truly new business keys and ensures the anti-join
+    # insert only brings in the unseen entity. The assertions confirm the
+    # persisted table matches the curated expectations rather than the raw
+    # landing order or casing.
+
+    connection.raw.execute(
+        """
+        CREATE TABLE dim_customers(
+            customer_id INTEGER,
+            email VARCHAR,
+            is_active BOOLEAN,
+            first_order_id INTEGER,
+            segment VARCHAR
+        )
+        """
+    )
+    table = DuckTable(connection, "dim_customers")
+
+    landing = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (1, 'ALPHA@example.com', 'active', 10),
+                    (2, 'BETA@example.com', 'inactive', 20)
+            ) AS landing(customer_id, email, status, first_order_id)
+            """
+        )
+    )
+    curated = landing.project(
+        {
+            "customer_id": "customer_id",
+            "email": "lower(email)",
+            "is_active": "status = 'active'",
+            "first_order_id": "first_order_id",
+            "segment": "CASE WHEN first_order_id < 15 THEN 'early' ELSE 'standard' END",
+        }
+    )
+    table.append(curated)
+
+    restage = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (2, 'beta@example.com', 'active', 20),
+                    (3, 'GAMMA@example.com', 'active', 22)
+            ) AS stage(customer_id, email, status, first_order_id)
+            """
+        )
+    )
+    deduplicated = restage.project(
+        {
+            "customer_id": "customer_id",
+            "email": "lower(email)",
+            "is_active": "status = 'active'",
+            "first_order_id": "first_order_id",
+            "segment": "CASE WHEN first_order_id < 15 THEN 'early' ELSE 'standard' END",
+        }
+    )
+    inserted = table.insert_antijoin(deduplicated, keys=["customer_id"])
+    assert inserted == 1
+
+    assert fetch_table_rows(connection, "dim_customers") == [
+        (1, "alpha@example.com", True, 10, "early"),
+        (2, "beta@example.com", False, 20, "standard"),
+        (3, "gamma@example.com", True, 22, "standard"),
+    ]
+
+
+
+def test_exploratory_streaming_fact_ingestion_flow(
+    connection: DuckConnection,
+) -> None:
+    """Integration-style fact ingestion run covering continuous ID helpers."""
+
+    # Exploratory integration context (mutable with approval): this sequence
+    # emulates a streaming catch-up pipeline to validate how helpers compose.
+
+    # A fact table ingestion walk-through that chains multiple DuckRel
+    # features.
+    #
+    # The flow builds a curated seed dataset by joining to a reference relation
+    # that standardizes source names before appending into the fact table. A
+    # second staging relation reuses the join, adds filtering, and is ingested
+    # through the continuous-ID helper to mimic streaming catch-up behaviour.
+    # A final relation exercises the inclusive branch of the ID filter to
+    # ensure duplicates at the boundary are ignored while newly observed IDs
+    # land.
+
+    connection.raw.execute(
+        """
+        CREATE TABLE fact_orders(
+            event_id INTEGER,
+            order_id INTEGER,
+            amount DOUBLE,
+            source VARCHAR,
+            processed_at TIMESTAMP
+        )
+        """
+    )
+    table = DuckTable(connection, "fact_orders")
+
+    origin_map = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    ('web', 'WEB'),
+                    ('store', 'STORE'),
+                    ('kiosk', 'KIOSK')
+            ) AS mapping(origin, source)
+            """
+        )
+    )
+
+    seed_events = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (100, 9001, 25.50, 'web', TIMESTAMP '2024-01-01 12:00:00'),
+                    (101, 9002, 40.00, 'store', TIMESTAMP '2024-01-01 13:30:00')
+            ) AS events(event_id, order_id, amount, origin, processed_at)
+            """
+        )
+    )
+    normalized_seed = seed_events.inner_join(origin_map, on=["origin"]).project_columns(
+        "event_id",
+        "order_id",
+        "amount",
+        "source",
+        "processed_at",
+    )
+    table.append(normalized_seed)
+
+    incremental_events = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (101, 9002, 40.00, 'store', TIMESTAMP '2024-01-01 13:30:00'),
+                    (102, 9003, 55.75, 'web', TIMESTAMP '2024-01-01 14:45:00'),
+                    (103, 9004, 60.00, 'kiosk', TIMESTAMP '2024-01-01 16:00:00')
+            ) AS events(event_id, order_id, amount, origin, processed_at)
+            """
+        )
+    )
+    incremental_curated = (
+        incremental_events.inner_join(origin_map, on=["origin"])
+        .filter("amount >= ?", 40)
+        .project_columns("event_id", "order_id", "amount", "source", "processed_at")
+    )
+    inserted = table.insert_by_continuous_id(incremental_curated, id_column="event_id")
+    assert inserted == 2
+
+    catch_up_events = DuckRel(
+        connection.raw.sql(
+            """
+            SELECT * FROM (
+                VALUES
+                    (103, 9004, 60.00, 'kiosk', TIMESTAMP '2024-01-01 16:00:00'),
+                    (104, 9005, 20.00, 'web', TIMESTAMP '2024-01-01 17:15:00')
+            ) AS events(event_id, order_id, amount, origin, processed_at)
+            """
+        )
+    )
+    catch_up_curated = catch_up_events.inner_join(origin_map, on=["origin"]).project_columns(
+        "event_id",
+        "order_id",
+        "amount",
+        "source",
+        "processed_at",
+    )
+    inserted_catch_up = table.insert_by_continuous_id(
+        catch_up_curated, id_column="event_id", inclusive=True
+    )
+    assert inserted_catch_up == 1
+
+    assert fetch_table_rows(connection, "fact_orders") == [
+        (100, 9001, 25.5, "WEB", datetime(2024, 1, 1, 12, 0, 0)),
+        (101, 9002, 40.0, "STORE", datetime(2024, 1, 1, 13, 30, 0)),
+        (102, 9003, 55.75, "WEB", datetime(2024, 1, 1, 14, 45, 0)),
+        (103, 9004, 60.0, "KIOSK", datetime(2024, 1, 1, 16, 0, 0)),
+        (104, 9005, 20.0, "WEB", datetime(2024, 1, 1, 17, 15, 0)),
+    ]


### PR DESCRIPTION
## Summary
- add mutable-with-approval DuckRel integration scenarios that chain joins, projections, ordering, and materialization to mirror feature engineering and backlog monitoring flows

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- exercises DuckRel across semi/anti joins, targeted projections, and materialization strategies without altering existing APIs, keeping the exploratory coverage easy to evolve via the existing marker

------
https://chatgpt.com/codex/tasks/task_e_68e879a79710832295fc70753318399d