### PR TITLE
Track column types and add casting helpers

### DIFF
--- a/src/duckplus/util.py
+++ b/src/duckplus/util.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from enum import Enum
 from os import PathLike, fspath
-from typing import Any
+from typing import Any, Literal, get_args
 
 import re
 
@@ -125,3 +125,35 @@ def coerce_scalar(value: Any) -> Any:
         return value.item()
 
     return value
+DuckDBType = Literal[
+    "BOOLEAN",
+    "TINYINT",
+    "SMALLINT",
+    "INTEGER",
+    "BIGINT",
+    "HUGEINT",
+    "UTINYINT",
+    "USMALLINT",
+    "UINTEGER",
+    "UBIGINT",
+    "FLOAT",
+    "REAL",
+    "DOUBLE",
+    "DECIMAL",
+    "NUMERIC",
+    "VARCHAR",
+    "BLOB",
+    "DATE",
+    "TIME",
+    "TIME_TZ",
+    "TIMESTAMP",
+    "TIMESTAMP_S",
+    "TIMESTAMP_MS",
+    "TIMESTAMP_NS",
+    "TIMESTAMP_TZ",
+    "INTERVAL",
+    "UUID",
+    "JSON",
+]
+DUCKDB_TYPE_SET: frozenset[str] = frozenset(get_args(DuckDBType))
+


### PR DESCRIPTION
## Summary
- track DuckDB column types in DuckRel metadata so transformations preserve schema details
- add cast_columns/try_cast_columns helpers with Literal-typed DuckDB targets and reuse them across projections
- extend core tests to cover type metadata propagation and new casting utilities

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design Notes
- DuckRel remains immutable while now carrying column type metadata alongside names; projection and join helpers thread that metadata explicitly so no implicit DuckDB behaviour is relied upon.
- Casting helpers compile explicit CAST/TRY_CAST projections, preserving column order and casing to align with project principles.


------
https://chatgpt.com/codex/tasks/task_e_68e9501a94508322bd1fd6776dbb5106