### PR TITLE
Improve error messaging throughout core modules

### DIFF
--- a/src/duckplus/materialize.py
+++ b/src/duckplus/materialize.py
@@ -127,14 +127,20 @@ class Materialized:
         """Return the Arrow table or raise if unavailable."""
 
         if self.table is None:
-            raise ValueError("Materialization strategy did not produce an Arrow table")
+            raise ValueError(
+                "Materialization strategy did not retain an Arrow table; "
+                "call require_table() only when the chosen strategy keeps a table in memory."
+            )
         return self.table
 
     def require_relation(self) -> DuckRel:
         """Return the materialized :class:`DuckRel` or raise if unavailable."""
 
         if self.relation is None:
-            raise ValueError("Materialization strategy did not produce a relation")
+            raise ValueError(
+                "Materialization strategy did not materialize into a relation; "
+                "ensure a target connection was provided when required."
+            )
         return self.relation
 
 

--- a/src/duckplus/table.py
+++ b/src/duckplus/table.py
@@ -21,7 +21,10 @@ def _normalize_table_reference(name: str) -> str:
     """Return a sanitized table reference supporting dotted paths."""
 
     if not isinstance(name, str):
-        raise TypeError("Table name must be a string")
+        raise TypeError(
+            "Table name must be provided as a string; "
+            f"received {type(name).__name__}."
+        )
 
     parts: list[str] = []
     current: list[str] = []
@@ -42,7 +45,10 @@ def _normalize_table_reference(name: str) -> str:
         if char == "." and not in_quotes:
             part = "".join(current).strip()
             if not part:
-                raise ValueError("Empty identifier segment in table name")
+                raise ValueError(
+                    "Table name contains an empty identifier segment around '.' separators; "
+                    f"original value {name!r}."
+                )
             util.ensure_identifier(part, allow_quoted=True)
             parts.append(part)
             current = []
@@ -52,11 +58,16 @@ def _normalize_table_reference(name: str) -> str:
         index += 1
 
     if in_quotes:
-        raise ValueError("Unterminated quoted identifier in table name")
+        raise ValueError(
+            f"Table name {name!r} contains an unterminated quoted identifier."
+        )
 
     part = "".join(current).strip()
     if not part:
-        raise ValueError("Empty identifier segment in table name")
+        raise ValueError(
+            "Table name contains an empty identifier segment around '.' separators; "
+            f"original value {name!r}."
+        )
     util.ensure_identifier(part, allow_quoted=True)
     parts.append(part)
 
@@ -87,7 +98,11 @@ class DuckTable:
             relation = rel.project_columns(*ordered)
         else:
             if len(rel.columns) != len(table_columns):
-                raise ValueError("Relation column count must match table when by_name is False")
+                raise ValueError(
+                    "Relation column count must match table when by_name is False; "
+                    f"relation has {len(rel.columns)} column(s) but table {self._name} "
+                    f"has {len(table_columns)} column(s)."
+                )
 
         relation.relation.insert_into(self._name)
 
@@ -95,7 +110,9 @@ class DuckTable:
         """Insert rows from *rel* missing in the table based on *keys*."""
 
         if not keys:
-            raise ValueError("At least one key column is required")
+            raise ValueError(
+                "insert_antijoin() requires at least one key column name."
+            )
 
         table_columns = self._table_columns()
         resolved_keys = util.resolve_columns(keys, table_columns)

--- a/src/duckplus/util.py
+++ b/src/duckplus/util.py
@@ -42,7 +42,10 @@ def ensure_identifier(name: str, *, allow_quoted: bool = False) -> str:
     """
 
     if not isinstance(name, str):
-        raise TypeError("Identifier must be a string")
+        raise TypeError(
+            "Identifier must be provided as a string; "
+            f"received {type(name).__name__}."
+        )
 
     if _IDENTIFIER_RE.fullmatch(name):
         return name
@@ -64,7 +67,10 @@ def normalize_columns(columns: Sequence[str]) -> tuple[list[str], dict[str, int]
 
     for index, column in enumerate(normalized):
         if not isinstance(column, str):
-            raise TypeError("Column names must be strings")
+            raise TypeError(
+                "Column names must be provided as strings; "
+                f"received {type(column).__name__}."
+            )
 
         key = column.casefold()
         if key in lookup:
@@ -94,7 +100,10 @@ def resolve_columns(
 
     for column in requested:
         if not isinstance(column, str):
-            raise TypeError("Requested column names must be strings")
+            raise TypeError(
+                "Requested column names must be provided as strings; "
+                f"received {type(column).__name__}."
+            )
 
         key = column.casefold()
         index = lookup.get(key)


### PR DESCRIPTION
## Summary
- enrich DuckRel join, projection, ordering, and materialization errors with detailed context on invalid values
- clarify DuckTable and utility validation errors to report offending types and identifiers
- add actionable guidance when requiring materialized tables or relations from strategies

## Testing
- `uv run pytest`
- `uv run mypy src/duckplus`
- `uvx ty check src/duckplus`

## Design notes
- changes are limited to raised exception messages and additional validation branches, preserving existing relational semantics
- no additional database queries or data copies were introduced, keeping performance characteristics unchanged

------
https://chatgpt.com/codex/tasks/task_e_68e99672bbd8832283deeec07f63faf4