### PR TITLE
Make secret registry connection-independent

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -111,6 +111,17 @@ Sequence:
 ## Stage 4 — Extras
 Only start extras once core and IO pieces are reliable.
 
+*Status*: 🔄 In progress — Stage 4.0 introduces credential helpers so future
+extras can authenticate against external systems without embedding secrets in
+code or configuration files.
+
+### Stage 4.0 — Secrets management
+*Status*: ✅ Completed — `SecretManager` and `SecretDefinition` provide a
+connection-independent registry with an in-memory fallback when the DuckDB
+``secrets`` extension is unavailable. Tests in `tests/test_secrets.py` cover
+validation, replacement, synchronization hooks, and error handling so future
+connection helpers can rely on predictable behavior.
+
 ### Module: `cli`
 - `def main(argv: Sequence[str] | None = None) -> int`
 - `def repl(conn: DuckConnection) -> None`

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ analytics pipelines that need safety as much as speed.
   table operations such as appends and insert strategies.
 - **Connection management** – `duckplus.connect()` is a context manager that yields a light connection facade and
   loads optional DuckDB extensions (e.g., `secrets`) only when they are available.
+- **Secrets-ready** – `SecretManager` fronts a connection-independent registry and
+  synchronizes entries into DuckDB when the optional `secrets` extension is
+  installed, so pipelines can avoid embedding passwords in code or config files.
 - **Opinionated defaults** – joins project columns explicitly, drop duplicate right-side keys, and error on naming
   collisions unless you explicitly opt into suffixes mirroring DuckDB (`_1`, `_2`).
 - **Case-aware column handling** – columns preserve their original case while still supporting case-insensitive
@@ -135,6 +138,7 @@ rows before inserting.
 src/duckplus/
   __init__.py      # public exports (`connect`, `DuckRel`, `DuckTable`, materialize helpers)
   connect.py       # connection context manager and facade
+  secrets.py       # credential registry with DuckDB sync hooks
   core.py          # `DuckRel` immutable relational wrapper
   materialize.py   # materialization strategies for DuckRel
   table.py         # `DuckTable` mutation helpers

--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -12,12 +12,13 @@ from .core import (
     JoinProjection,
     JoinSpec,
 )
-from .table import DuckTable
 from .materialize import (
     ArrowMaterializeStrategy,
     Materialized,
     ParquetMaterializeStrategy,
 )
+from .secrets import SecretDefinition, SecretManager, SecretRecord, SecretRegistry
+from .table import DuckTable
 
 __all__ = [
     "ArrowMaterializeStrategy",
@@ -32,5 +33,9 @@ __all__ = [
     "JoinSpec",
     "Materialized",
     "ParquetMaterializeStrategy",
+    "SecretDefinition",
+    "SecretManager",
+    "SecretRecord",
+    "SecretRegistry",
     "connect",
 ]

--- a/src/duckplus/secrets.py
+++ b/src/duckplus/secrets.py
@@ -1,0 +1,230 @@
+"""Secret management helpers for Duck+."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+import duckdb
+
+from . import util
+from .connect import DuckConnection
+
+
+def _quote(value: str) -> str:
+    """Return a SQL-quoted representation of *value*."""
+
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+@dataclass(frozen=True, slots=True)
+class SecretDefinition:
+    """Definition for a DuckDB secret."""
+
+    name: str
+    engine: str
+    parameters: Mapping[str, str]
+
+    def normalized(self) -> "SecretRecord":
+        """Return a normalized, validated representation of the secret."""
+
+        normalized_name = util.ensure_identifier(self.name, allow_quoted=True)
+        normalized_engine = util.ensure_identifier(self.engine, allow_quoted=True)
+        normalized_parameters: list[tuple[str, str]] = []
+        for key, value in self.parameters.items():
+            normalized_key = util.ensure_identifier(key, allow_quoted=True)
+            normalized_parameters.append((normalized_key, str(value)))
+        return SecretRecord(
+            name=normalized_name,
+            engine=normalized_engine,
+            parameters=tuple(normalized_parameters),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SecretRecord:
+    """Concrete record for a stored secret."""
+
+    name: str
+    engine: str
+    parameters: tuple[tuple[str, str], ...]
+
+    def to_definition(self) -> SecretDefinition:
+        """Convert the record back into a :class:`SecretDefinition`."""
+
+        return SecretDefinition(
+            name=self.name,
+            engine=self.engine,
+            parameters=dict(self.parameters),
+        )
+
+
+class SecretRegistry:
+    """Connection-independent registry for DuckDB secrets."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, SecretRecord] = {}
+
+    def has_secret(self, name: str) -> bool:
+        """Return ``True`` if a secret named *name* exists."""
+
+        normalized = util.ensure_identifier(name, allow_quoted=True)
+        return normalized in self._store
+
+    def list_secrets(self) -> list[SecretRecord]:
+        """Return all stored secrets."""
+
+        return list(self._store.values())
+
+    def get_secret(self, name: str) -> SecretRecord | None:
+        """Return the secret named *name* when it exists."""
+
+        normalized = util.ensure_identifier(name, allow_quoted=True)
+        return self._store.get(normalized)
+
+    def save(self, record: SecretRecord, *, replace: bool = False) -> bool:
+        """Save *record* and report whether it replaced an existing secret."""
+
+        existing = self._store.get(record.name)
+        if existing is not None and not replace:
+            raise ValueError(f"Secret already exists: {record.name}")
+        self._store[record.name] = record
+        return existing is not None
+
+    def drop_secret(self, name: str) -> SecretRecord:
+        """Remove *name* from the registry and return the stored record."""
+
+        normalized = util.ensure_identifier(name, allow_quoted=True)
+        try:
+            return self._store.pop(normalized)
+        except KeyError as exc:  # pragma: no cover - defensive, error rewording only
+            raise KeyError(f"Secret not found: {normalized}") from exc
+
+
+_GLOBAL_SECRET_REGISTRY = SecretRegistry()
+
+
+class SecretManager:
+    """Manage DuckDB secrets with graceful fallback when the extension is missing."""
+
+    def __init__(
+        self,
+        connection: DuckConnection,
+        *,
+        registry: SecretRegistry | None = None,
+        auto_load: bool = True,
+    ) -> None:
+        self._connection = connection
+        self._registry = registry or _GLOBAL_SECRET_REGISTRY
+        self._extension_state: str = "unknown"
+        if auto_load:
+            self.ensure_extension()
+
+    @property
+    def connection(self) -> DuckConnection:
+        """Return the wrapped Duck+ connection."""
+
+        return self._connection
+
+    @property
+    def registry(self) -> SecretRegistry:
+        """Return the connection-independent registry backing the manager."""
+
+        return self._registry
+
+    def ensure_extension(self) -> bool:
+        """Attempt to load the DuckDB ``secrets`` extension.
+
+        Returns ``True`` when the extension is available. Errors encountered while
+        loading the extension are swallowed, allowing callers to rely on the
+        in-memory fallback store.
+        """
+
+        if self._extension_state == "available":
+            return True
+        if self._extension_state == "missing":
+            return False
+
+        raw = self._connection.raw
+        try:
+            raw.execute("LOAD secrets")
+        except duckdb.Error:  # pragma: no cover - executed only when DuckDB raises
+            self._extension_state = "missing"
+            return False
+        else:
+            self._extension_state = "available"
+            return True
+
+    def has_secret(self, name: str) -> bool:
+        """Return ``True`` when a secret with *name* exists."""
+
+        return self._registry.has_secret(name)
+
+    def list_secrets(self) -> list[SecretRecord]:
+        """Return the stored secrets as :class:`SecretRecord` instances."""
+
+        return self._registry.list_secrets()
+
+    def get_secret(self, name: str) -> SecretRecord | None:
+        """Retrieve *name* as a :class:`SecretRecord` when present."""
+
+        return self._registry.get_secret(name)
+
+    def create_secret(self, definition: SecretDefinition, *, replace: bool = False) -> SecretRecord:
+        """Create a secret and return the stored :class:`SecretRecord`.
+
+        When the DuckDB ``secrets`` extension is available the definition is
+        mirrored into the underlying connection. Otherwise the secret is retained
+        solely within Duck+ so higher-level connection helpers can reference it
+        later.
+        """
+
+        record = definition.normalized()
+        replaced = self._registry.save(record, replace=replace)
+
+        if self.ensure_extension():
+            if replaced:
+                self._connection.raw.execute(f"DROP SECRET IF EXISTS {record.name}")
+            self._create_in_duckdb(record)
+
+        return record
+
+    def drop_secret(self, name: str) -> None:
+        """Remove the secret named *name* from Duck+ (and DuckDB when available)."""
+
+        record = self._registry.drop_secret(name)
+
+        if self._extension_state == "available":
+            self._connection.raw.execute(f"DROP SECRET IF EXISTS {record.name}")
+
+    def sync(self, names: Sequence[str] | None = None) -> None:
+        """Synchronize stored secrets into DuckDB when the extension loads later."""
+
+        if not self.ensure_extension():
+            return
+
+        if names is None:
+            records = self._registry.list_secrets()
+        else:
+            records = []
+            for name in names:
+                record = self._registry.get_secret(name)
+                if record is None:
+                    normalized = util.ensure_identifier(name, allow_quoted=True)
+                    raise KeyError(f"Secret not found: {normalized}")
+                records.append(record)
+
+        for record in records:
+            self._create_in_duckdb(record, replace=True)
+
+    def _create_in_duckdb(self, record: SecretRecord, *, replace: bool = False) -> None:
+        raw = self._connection.raw
+        if replace:
+            raw.execute(f"DROP SECRET IF EXISTS {record.name}")
+
+        assignments = [f"TYPE {record.engine}"]
+        for key, value in record.parameters:
+            assignments.append(f"{key} {_quote(value)}")
+        clause = ", ".join(assignments)
+        raw.execute(f"CREATE SECRET {record.name} ({clause})")

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,0 +1,114 @@
+"""Tests for Duck+ secret helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from duckplus import SecretDefinition, SecretManager, SecretRegistry, connect
+
+
+@pytest.fixture()
+def registry() -> SecretRegistry:
+    return SecretRegistry()
+
+
+def test_secret_definition_validation() -> None:
+    secret = SecretDefinition(
+        name="storage_creds",
+        engine="S3",
+        parameters={"KEY_ID": "abc", "SECRET": "xyz"},
+    )
+    record = secret.normalized()
+    assert record.name == "storage_creds"
+    assert record.engine == "S3"
+    assert record.parameters == (("KEY_ID", "abc"), ("SECRET", "xyz"))
+
+    with pytest.raises(ValueError):
+        SecretDefinition(name="not valid", engine="S3", parameters={}).normalized()
+
+    with pytest.raises(TypeError):
+        SecretDefinition(name="ok", engine="S3", parameters={1: "value"}).normalized()  # type: ignore[arg-type]
+
+
+def test_secret_manager_fallback_roundtrip(registry: SecretRegistry) -> None:
+    with connect() as conn:
+        manager = SecretManager(conn, registry=registry, auto_load=False)
+        assert manager.ensure_extension() is False
+
+        record = manager.create_secret(
+            SecretDefinition(
+                name="app_secret",
+                engine="S3",
+                parameters={"KEY_ID": "k", "SECRET": "s"},
+            )
+        )
+        assert manager.has_secret("app_secret")
+        assert manager.get_secret("app_secret") == record
+        assert manager.list_secrets() == [record]
+
+        with pytest.raises(ValueError):
+            manager.create_secret(
+                SecretDefinition(
+                    name="app_secret",
+                    engine="S3",
+                    parameters={"KEY_ID": "other", "SECRET": "other"},
+                )
+            )
+
+        updated = manager.create_secret(
+            SecretDefinition(
+                name="app_secret",
+                engine="S3",
+                parameters={"KEY_ID": "other", "SECRET": "other"},
+            ),
+            replace=True,
+        )
+        assert updated.parameters == (("KEY_ID", "other"), ("SECRET", "other"))
+
+    with connect() as other_conn:
+        other_manager = SecretManager(other_conn, registry=registry, auto_load=False)
+        assert other_manager.has_secret("app_secret")
+        assert other_manager.get_secret("app_secret") == updated
+
+        other_manager.drop_secret("app_secret")
+
+    with pytest.raises(KeyError):
+        registry.drop_secret("app_secret")
+
+
+def test_drop_missing_secret_errors(registry: SecretRegistry) -> None:
+    with connect() as conn:
+        manager = SecretManager(conn, registry=registry, auto_load=False)
+        with pytest.raises(KeyError):
+            manager.drop_secret("missing")
+
+
+def test_sync_replays_to_duckdb(
+    registry: SecretRegistry, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    with connect() as conn:
+        manager = SecretManager(conn, registry=registry, auto_load=False)
+        manager.create_secret(
+            SecretDefinition(
+                name="sync_me",
+                engine="S3",
+                parameters={"KEY_ID": "k", "SECRET": "s"},
+            )
+        )
+
+        recorded: list[tuple[str, tuple[tuple[str, str], ...], bool]] = []
+
+        def fake_create(record, *, replace: bool = False) -> None:
+            recorded.append((record.name, record.parameters, replace))
+
+        monkeypatch.setattr(manager, "_create_in_duckdb", fake_create)
+        monkeypatch.setattr(manager, "ensure_extension", lambda: True)
+
+        manager.sync()
+        assert recorded == [("sync_me", (("KEY_ID", "k"), ("SECRET", "s")), True)]
+
+        manager.sync(names=["sync_me"])
+        assert recorded[-1] == ("sync_me", (("KEY_ID", "k"), ("SECRET", "s")), True)
+
+        with pytest.raises(KeyError):
+            manager.sync(names=["missing"]) 


### PR DESCRIPTION
## Summary
- ensure `SecretManager` persists secrets in a connection-independent registry, syncs them to DuckDB when available, and expose the registry through the public API
- update Stage 4.0 documentation to describe the global registry behaviour
- extend the secret helper tests to cover cross-connection reuse, missing-secret errors, and registry injection

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- secrets stay in-memory until the DuckDB `secrets` extension loads, avoiding unencrypted table storage
- the shared registry preserves the package's non-interactive design while keeping credentials consistent across connections


------
https://chatgpt.com/codex/tasks/task_e_68e99ae839b48322adb079c15559a69d