### PR TITLE
Add HTML rendering helper for DuckRel previews

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,11 +153,29 @@ All commands operate against an in-memory DuckDB database unless you supply `--d
 connections are opened in read-only mode so ad-hoc exploration stays safe, while the in-memory default remains isolated to
 the current process.
 
+## HTML previews
+
+For quick notebook previews Duck+ includes a lightweight HTML renderer that works entirely inside DuckDB. The helper limits
+rows, escapes every value, and annotates the output when additional records were truncated.
+
+```python
+from duckplus import DuckRel, connect, to_html
+
+with connect() as conn:
+    rel = DuckRel(conn.raw.sql("SELECT 1 AS id, 'Alice & Bob' AS name UNION ALL SELECT 2, NULL"))
+
+html = to_html(rel, max_rows=10, null_display="∅", class_="preview")
+```
+
+By default NULL values render as a blank cell, but you can supply `null_display` to use an explicit marker. Optional `class_`
+and `id` keyword arguments attach CSS hooks without embedding styles directly in the markup.
+
 ## Project layout
 
 ```
 src/duckplus/
   cli.py          # read-only command line interface (extras module)
+  html.py         # HTML rendering helper (extras module)
   __init__.py      # public exports (`connect`, `DuckRel`, `DuckTable`, materialize helpers)
   connect.py       # connection context manager and facade
   secrets.py       # credential registry with DuckDB sync hooks

--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -13,6 +13,7 @@ from .core import (
     JoinProjection,
     JoinSpec,
 )
+from .html import to_html
 from .io import (
     append_csv,
     append_parquet,
@@ -57,5 +58,6 @@ __all__ = [
     "SecretRegistry",
     "write_csv",
     "write_parquet",
+    "to_html",
     "connect",
 ]

--- a/src/duckplus/html.py
+++ b/src/duckplus/html.py
@@ -1,0 +1,132 @@
+"""HTML rendering helpers for Duck+."""
+from __future__ import annotations
+
+from html import escape as html_escape
+from typing import Any
+
+from .core import DuckRel
+
+
+def _quote_identifier(identifier: str) -> str:
+    """Return *identifier* quoted for SQL usage."""
+
+    return f'"{identifier.replace("\"", "\"\"")}"'
+
+
+def _sql_literal(value: str) -> str:
+    """Return a SQL string literal for *value*."""
+
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _validate_attributes(style: dict[str, Any]) -> str:
+    """Return serialized table attributes from *style*."""
+
+    allowed_attrs = {"class", "id"}
+    fragments: list[str] = []
+    for key, raw_value in style.items():
+        attr = key[:-1] if key.endswith("_") else key
+        if attr not in allowed_attrs:
+            raise ValueError(
+                "Unsupported HTML attribute provided; only 'class' and 'id' attributes are permitted."
+            )
+        value = html_escape(str(raw_value), quote=True)
+        fragments.append(f" {attr}=\"{value}\"")
+    return "".join(fragments)
+
+
+def _build_row_expression(columns: list[str], null_literal: str) -> str:
+    """Return the SQL expression that renders a table row."""
+
+    if not columns:
+        return "'<tr></tr>'"
+
+    cells: list[str] = []
+    replacements = [
+        ("&", "&amp;"),
+        ("<", "&lt;"),
+        (">", "&gt;"),
+        ('"', "&quot;"),
+        ("'", "&#x27;"),
+    ]
+    for column in columns:
+        identifier = _quote_identifier(column)
+        value_ref = f"numbered.{identifier}"
+        escaped = f"CAST({value_ref} AS VARCHAR)"
+        for source, target in replacements:
+            escaped = f"REPLACE({escaped}, {_sql_literal(source)}, {_sql_literal(target)})"
+        value_expression = (
+            f"CASE WHEN {value_ref} IS NULL THEN {null_literal} ELSE {escaped} END"
+        )
+        cells.append(f"'<td>' || {value_expression} || '</td>'")
+
+    inner = " || ".join(cells)
+    return f"'<tr>' || {inner} || '</tr>'"
+
+
+def to_html(
+    rel: DuckRel,
+    *,
+    max_rows: int = 100,
+    null_display: str = "",
+    **style: Any,
+) -> str:
+    """Return an HTML table preview of *rel* limited to *max_rows* rows.
+
+    Values are escaped inside DuckDB before rendering to avoid materializing Python objects unnecessarily. When the
+    relation contains more than ``max_rows`` rows a ``<tfoot>`` entry summarizes how many records were not rendered.
+    """
+
+    if not isinstance(max_rows, int):
+        raise TypeError("max_rows must be provided as an integer.")
+    if max_rows < 0:
+        raise ValueError("max_rows must be non-negative.")
+
+    table_attributes = _validate_attributes(dict(style))
+    columns = rel.columns
+    escaped_headers = "".join(f"<th>{html_escape(name)}</th>" for name in columns)
+    header_html = f"<thead><tr>{escaped_headers}</tr></thead>"
+
+    relation = rel.relation
+    total_count_row = relation.aggregate("COUNT(*)").fetchone()
+    total_count = int(total_count_row[0]) if total_count_row is not None else 0
+
+    body_rows_html = ""
+    if max_rows > 0 and total_count > 0:
+        null_literal = _sql_literal(html_escape(str(null_display)))
+        row_expression = _build_row_expression(columns, null_literal)
+        query = f"""
+            WITH limited AS (
+                SELECT *
+                FROM __duckplus_rel
+                LIMIT {max_rows}
+            ),
+            numbered AS (
+                SELECT *, ROW_NUMBER() OVER () AS __rownum
+                FROM limited
+            )
+            SELECT
+                COALESCE(
+                    STRING_AGG({row_expression}, '' ORDER BY __rownum),
+                    ''
+                )
+            FROM numbered
+        """
+        result = relation.query("__duckplus_rel", query).fetchone()
+        body_rows_html = str(result[0]) if result and result[0] is not None else ""
+
+    tbody_html = f"<tbody>{body_rows_html}</tbody>"
+
+    shown = min(max_rows, total_count)
+    footer_html = ""
+    if total_count > max_rows:
+        remaining = total_count - max_rows
+        row_word = "row" if remaining == 1 else "rows"
+        colspan = max(len(columns), 1)
+        summary = (
+            f"Showing first {shown} of {total_count} rows "
+            f"({remaining} more {row_word} not shown)."
+        )
+        footer_html = f"<tfoot><tr><td colspan=\"{colspan}\">{summary}</td></tr></tfoot>"
+
+    return f"<table{table_attributes}>{header_html}{tbody_html}{footer_html}</table>"

--- a/tests/test_html.py
+++ b/tests/test_html.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import duckdb
+import pytest
+
+from duckplus.core import DuckRel
+from duckplus.html import to_html
+
+
+@pytest.fixture()
+def connection() -> duckdb.DuckDBPyConnection:
+    conn = duckdb.connect()
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture()
+def sample_rel(connection: duckdb.DuckDBPyConnection) -> DuckRel:
+    relation = connection.sql(
+        """
+        SELECT *
+        FROM (VALUES
+            (1, 'Alpha & <Beta>', 'note'),
+            (2, '"Gamma"', NULL)
+        ) AS t(id, label, details)
+        ORDER BY id
+        """
+    )
+    return DuckRel(relation)
+
+
+def test_to_html_renders_table_with_escaped_values(sample_rel: DuckRel) -> None:
+    html = to_html(sample_rel)
+
+    assert html.startswith("<table")
+    assert "<thead><tr><th>id</th><th>label</th><th>details</th></tr></thead>" in html
+    assert "Alpha &amp; &lt;Beta&gt;" in html
+    assert "&quot;Gamma&quot;" in html
+    assert "<td></td>" in html  # NULL defaults to blank
+
+
+def test_to_html_supports_custom_null_display(sample_rel: DuckRel) -> None:
+    html = to_html(sample_rel, null_display="(null)")
+
+    assert "<td>(null)</td>" in html
+
+
+def test_to_html_respects_row_limit_and_footer(connection: duckdb.DuckDBPyConnection) -> None:
+    relation = connection.sql(
+        """
+        SELECT *
+        FROM (VALUES (1), (2), (3), (4), (5)) AS t(id)
+        ORDER BY id
+        """
+    )
+    rel = DuckRel(relation)
+
+    html = to_html(rel, max_rows=3)
+    body = html.split("<tbody>")[1].split("</tbody>")[0]
+
+    assert body.count("<tr>") == 3
+    assert "<td>4</td>" not in body
+    assert (
+        "<tfoot><tr><td colspan=\"1\">Showing first 3 of 5 rows (2 more rows not shown).</td></tr></tfoot>"
+        in html
+    )
+
+
+def test_to_html_applies_supported_attributes(sample_rel: DuckRel) -> None:
+    html = to_html(sample_rel, class_="preview", id="table-1")
+
+    assert html.startswith('<table class="preview" id="table-1">')
+
+
+def test_to_html_rejects_negative_limits(sample_rel: DuckRel) -> None:
+    with pytest.raises(ValueError):
+        to_html(sample_rel, max_rows=-1)


### PR DESCRIPTION
## Summary
- implement a DuckRel.to_html helper that renders limited, escaped table previews directly in DuckDB with configurable null display and optional class/id attributes
- export the HTML helper publicly and document usage along with the new extras module layout entry
- add unit tests covering escaping, truncation footer messaging, styling hooks, and validation edge cases

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- rendering work stays inside DuckDB to avoid materializing large relations, aligns with immutability and non-interactive principles
- HTML output is minimal (<table>/<thead>/<tbody>/<tfoot>) and escapes all values to preserve safety while supporting optional styling hooks


------
https://chatgpt.com/codex/tasks/task_e_68e9e634325083229930bd57b84ccb19