### PR TITLE
Declare setuptools src layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,15 @@ html = []
 [project.scripts]
 duckplus = "duckplus.cli:main"
 
+[tool.setuptools]
+package-dir = { "" = "src" }
+packages = ["duckplus"]
+
 [tool.setuptools.package-data]
 duckplus = ["py.typed"]
 
 [build-system]
-requires = ["uv>=0.2", "setuptools>=69", "wheel"]
+requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.uv]


### PR DESCRIPTION
## Summary
- declare the setuptools `src` layout so wheels and sdists pick up `duckplus`
- drop the unused `uv` build dependency and retain the back-end requirements only

## Testing
- uv build
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- packaging metadata only; core module structure and design principles remain unchanged.

------
https://chatgpt.com/codex/tasks/task_e_68eab0823e008322a6911af8d8a4cd1c