### PR TITLE
Add uv-based CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv ${{ matrix.python-version }}
+        uses: astral-sh/setup-uv@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Sync dependencies
+        run: uv sync
+
+      - name: Run pytest
+        run: uv run pytest
+
+      - name: Run mypy
+        run: uv run mypy src/duckplus
+
+      - name: Run ty
+        run: uvx ty check src/duckplus

--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ uv sync
 
 This will create and manage the virtual environment with development dependencies (pytest, mypy, and friends).
 
+## Continuous integration
+
+Every push to `main` and pull request targeting `main` runs the [CI workflow](.github/workflows/ci.yml). The job
+provisions Python 3.12 and 3.13 via `astral-sh/setup-uv`, installs project dependencies with `uv sync`, and then runs
+three gates:
+
+- `uv run pytest` for the test suite
+- `uv run mypy src/duckplus` for strict type checking
+- `uvx ty check src/duckplus` for the Rust-based static analysis helper
+
+All three steps must succeed for the workflow to pass, matching the local developer commands.
+
 ## Quickstart
 
 ```python


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs uv-managed tests and type checks on pushes and pull requests to main
- document the automated CI gates in the README so contributors know what runs before releases

## Testing
- uv sync
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- mirrors the documented development commands on Python 3.12 and 3.13 without changing runtime behavior or dependencies

------
https://chatgpt.com/codex/tasks/task_e_68eab1aa749083229076a38036cb25e2