### PR TITLE
Add PyPI publishing guidance and expose package version

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Looking for end-to-end walkthroughs? Explore the scenario-driven
 joins, ingestion patterns, IO helpers, secrets management, materialization
 strategies, and the CLI.
 
+## Publishing to PyPI
+
+Ready to cut a release? Follow the [publishing checklist](docs/publishing.md)
+for the commands to run and the `uv` workflow to ship Duck+ to PyPI safely.
+
 ### Join interface
 
 Duck+ exposes two families of joins: *natural* helpers that line up shared

--- a/docs/api_reference.md
+++ b/docs/api_reference.md
@@ -249,7 +249,7 @@ from DuckDB or the filesystem are surfaced as user-friendly messages.【F:src/du
 
 Importing from `duckplus` provides all of the classes and helpers documented
 above through the module's ``__all__`` definition, making `from duckplus import
-DuckRel, DuckTable, connect` the canonical entry point for most applications.【F:src/duckplus/__init__.py†L1-L44】
+DuckRel, DuckTable, connect` the canonical entry point for most applications.【F:src/duckplus/__init__.py†L64-L94】
 
 ## Demo walkthroughs
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,74 @@
+# Publishing Duck+ (`duckplus`) to PyPI
+
+Duck+ ships as a standard Python distribution managed by `uv`. Follow this
+checklist to cut a release and publish it to PyPI.
+
+## 1. Prepare the release branch
+
+1. Update the version in `pyproject.toml`.
+2. Commit the change with an informative message (for example,
+   `Prepare release X.Y.Z`).
+3. Ensure `duckplus.__version__` reports the same value by importing it from a
+   local checkout (this happens automatically when the project version changes).
+
+## 2. Run the validation suite
+
+Run the same checks that CI executes. All commands are mediated through `uv`:
+
+```bash
+uv run pytest
+uv run mypy src/duckplus
+uvx ty check src/duckplus
+```
+
+If any step fails, fix the regressions before proceeding.
+
+## 3. Build distribution artifacts
+
+Use `uv build` to produce the source distribution (`sdist`) and wheel:
+
+```bash
+uv build
+```
+
+The outputs land in the `dist/` directory. Inspect the metadata with
+`uv build --wheel --sdist --out-dir dist/` if you need to regenerate them.
+
+## 4. Smoke-test the wheel
+
+Install the freshly built wheel into a temporary environment to make sure the
+public API imports correctly:
+
+```bash
+uv pip install --python 3.12 dist/duckplus-*.whl
+uv run --python 3.12 python -c "import duckplus; print(duckplus.__version__)"
+```
+
+When finished, remove the temporary environment or uninstall the package using
+`uv pip uninstall --python 3.12 duckplus` from the same interpreter.
+
+## 5. Publish to PyPI
+
+Export an API token with publishing permissions and push the release using
+`uv publish`:
+
+```bash
+export PYPI_TOKEN="pypi-..."
+uv publish --token "$PYPI_TOKEN"
+```
+
+`uv publish` uploads both the wheel and source distribution while preserving the
+metadata declared in `pyproject.toml`.
+
+## 6. Tag the release
+
+After the upload succeeds, create a git tag that matches the version string and
+push it to GitHub so future changelog entries can reference it:
+
+```bash
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+Document the release in your changelog if new user-facing features shipped as
+part of the version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,13 +3,29 @@ name = "duckplus"                     # PyPI-safe name; brand "Duck+"
 version = "0.0.1"
 description = "Pythonic, typed wrappers for DuckDB relations and tables (Duck+)."
 readme = "README.md"
-license = "MIT"
+license = { file = "LICENSE" }
 authors = [{ name = "Isaac Moore" }]
 requires-python = ">=3.12"
 dependencies = [
     "duckdb>=1.3.0",
     "pyarrow>=16.1",
 ]
+keywords = ["duckdb", "analytics", "data-engineering", "etl"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Database",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+]
+
+[project.urls]
+Homepage = "https://github.com/isaacmoore/duckplus"
+Documentation = "https://github.com/isaacmoore/duckplus/tree/main/docs"
+Issues = "https://github.com/isaacmoore/duckplus/issues"
 
 # Optional extras (keep minimal; ODBC removed — loaded at runtime if needed)
 [project.optional-dependencies]

--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from importlib import metadata
+from pathlib import Path
+import tomllib
+
 from .cli import main as cli_main
 from .connect import DuckConnection, connect
 from .core import (
@@ -33,6 +37,30 @@ from .materialize import (
 from .secrets import SecretDefinition, SecretManager, SecretRecord, SecretRegistry
 from .table import DuckTable
 
+
+def _load_version() -> str:
+    """Return the installed distribution version.
+
+    When Duck+ is imported from a source checkout (e.g., in tests), fall back to
+    the `pyproject.toml` version so developers see the same identifier that will
+    be published to PyPI.
+    """
+
+    try:
+        return metadata.version("duckplus")
+    except metadata.PackageNotFoundError:
+        root = Path(__file__).resolve().parents[2]
+        pyproject = root / "pyproject.toml"
+        if not pyproject.exists():
+            return "0.0.0"
+        data = tomllib.loads(pyproject.read_text())
+        project = data.get("project", {})
+        version = project.get("version")
+        return version or "0.0.0"
+
+
+__version__ = _load_version()
+
 __all__ = [
     "ArrowMaterializeStrategy",
     "append_csv",
@@ -58,8 +86,9 @@ __all__ = [
     "SecretManager",
     "SecretRecord",
     "SecretRegistry",
+    "to_html",
     "write_csv",
     "write_parquet",
-    "to_html",
     "connect",
+    "__version__",
 ]

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+import duckplus
+
+
+def test_duckplus_version_matches_pyproject() -> None:
+    """The importable version must mirror the packaged metadata."""
+
+    project_root = Path(__file__).resolve().parents[1]
+    pyproject = project_root / "pyproject.toml"
+    pyproject_data = tomllib.loads(pyproject.read_text())
+    project_section = pyproject_data["project"]
+
+    assert duckplus.__version__ == project_section["version"]


### PR DESCRIPTION
## Summary
- document the PyPI release workflow in a dedicated publishing guide and surface it from the README
- add distribution metadata (license table, keywords, classifiers, project URLs) to pyproject.toml
- expose duckplus.__version__ with a pyproject fallback and cover it with a regression test

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- the version helper reads pyproject.toml only when importlib.metadata cannot find an installed distribution, so normal imports remain fast while source checkouts stay consistent with release numbers
- packaging metadata aligns with PyPI requirements without changing runtime behaviour or introducing new dependencies

------
https://chatgpt.com/codex/tasks/task_e_68eaba1d75f4832285d63c687628b1d4