### PR TITLE
Add DuckConnection IO conveniences

### DIFF
--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -35,6 +35,11 @@ def test_connect_applies_configuration(monkeypatch) -> None:
     assert captured_config["config"] == {"Threads": "1"}
 
 
+def test_connect_module_exposes_odbc_strategies() -> None:
+    assert connect_mod.MySQLStrategy is duckplus.MySQLStrategy
+    assert connect_mod.PostgresStrategy is duckplus.PostgresStrategy
+
+
 def test_load_extensions_validates_names() -> None:
     class StubConnection:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary
- add DuckConnection.read_parquet/read_csv/read_json that delegate to the existing io helpers and lazily expose the MySQL/Postgres ODBC strategies from duckplus.connect
- refresh the API reference to document connection-scoped IO usage and ensure the MySQL/Postgres helpers are mentioned in that namespace
- update the IO and connection tests to exercise the new methods and namespace exposure while keeping append/write behaviour unchanged

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- the io module entry points remain in place so existing callers continue to work while the connection methods offer the requested ergonomics
- the lazy module-level __getattr__ avoids importing duckplus.odbc during connect initialization, preserving the existing import order and preventing circular references


------
https://chatgpt.com/codex/tasks/task_e_68ead91a86388322933a08fd46552e2d