### PR TITLE
Add DuckRel.split helper for partitioning relations

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ with connect() as conn:
     table = top_scores.materialize().require_table()
     print(table.to_pylist())
 
+    # Need both halves of a filter? `split()` partitions rows without mutating `base`.
+    passing, failing = base.split('"score" >= ?', 8)
+    print(passing.materialize().require_table().to_pylist())
+    print(failing.materialize().require_table().to_pylist())
+
     # Need to persist results? Promote the relation to a table wrapper and append safely.
     conn.raw.execute("CREATE TABLE scores(id INTEGER, name VARCHAR, score INTEGER)")
     table_wrapper = DuckTable(conn, "scores")


### PR DESCRIPTION
## Summary
- add a DuckRel.split() helper that partitions a relation into matching and remainder subsets using the existing filter semantics
- reuse shared filter expression rendering logic and document the new helper in the README quickstart
- cover the new behavior with unit tests that confirm parameter handling and null rows are preserved in the remainder partition

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- split() relies on DuckDB filtering for both branches and wraps the negated branch with COALESCE(...) to ensure NULL evaluations land in the remainder partition, preserving deterministic casing and projection metadata
- the helper builds on the existing immutability model: both relations are created from the original relation without mutations or extra projections


------
https://chatgpt.com/codex/tasks/task_e_68eadec53b948322a40169653a9da602