### PR TITLE
Add DuckRel.show passthrough helper

### DIFF
--- a/src/duckplus/duckrel.py
+++ b/src/duckplus/duckrel.py
@@ -219,6 +219,12 @@ class DuckRel:
 
         return list(self._types)
 
+    def show(self) -> DuckRel:
+        """Render the relation using DuckDB's pretty printer and return ``self``."""
+
+        self._relation.show()
+        return self
+
     def project_columns(self, *columns: str, missing_ok: bool = False) -> DuckRel:
         """Return a relation containing only the requested *columns*."""
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -61,6 +61,15 @@ def test_column_types_metadata(sample_rel: DuckRel) -> None:
     assert sample_rel.column_types == ["INTEGER", "VARCHAR", "INTEGER"]
 
 
+def test_show_passthrough_returns_relation(sample_rel: DuckRel, capsys: pytest.CaptureFixture[str]) -> None:
+    rel = sample_rel.show()
+
+    captured = capsys.readouterr()
+    assert "Name" in captured.out
+    assert "Alpha" in captured.out
+    assert rel is sample_rel
+
+
 def test_project_columns_case_insensitive(sample_rel: DuckRel) -> None:
     selected = sample_rel.project_columns("name", "ID")
     assert selected.columns == ["Name", "id"]


### PR DESCRIPTION
## Summary
- add a `DuckRel.show()` passthrough that renders using DuckDB's builtin pretty printer and returns the original relation for chaining
- exercise the new method with a core test that captures console output and verifies the relation instance is unchanged

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design notes
- delegating to DuckDB's native `show` avoids custom formatting, honors console sizing, and preserves DuckRel immutability by returning `self`


------
https://chatgpt.com/codex/tasks/task_e_68eae23f181c8322bdd5a47ea869afca