### PR TITLE
Add convenience DuckConnection.table helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ All three steps must succeed for the workflow to pass, matching the local develo
 ## Quickstart
 
 ```python
-from duckplus import DuckRel, DuckTable, connect
+from duckplus import DuckRel, connect
 
 with connect() as conn:
     base = DuckRel(
@@ -89,7 +89,7 @@ with connect() as conn:
 
     # Need to persist results? Promote the relation to a table wrapper and append safely.
     conn.raw.execute("CREATE TABLE scores(id INTEGER, name VARCHAR, score INTEGER)")
-    table_wrapper = DuckTable(conn, "scores")
+    table_wrapper = conn.table("scores")
     table_wrapper.insert_antijoin(top_scores, keys=["id"])
 ```
 

--- a/src/duckplus/connect.py
+++ b/src/duckplus/connect.py
@@ -16,6 +16,7 @@ from .core import DuckRel
 if TYPE_CHECKING:
     from . import io as io_module
     from .odbc import MySQLStrategy, PostgresStrategy
+    from .table import DuckTable
 
 Pathish = str | PathLike[str]
 
@@ -149,6 +150,13 @@ class DuckConnection(AbstractContextManager["DuckConnection"]):
         from . import io as io_module
 
         return io_module.read_json(self, paths, **options)
+
+    def table(self, name: str) -> "DuckTable":
+        """Return a :class:`DuckTable` wrapper for *name* on this connection."""
+
+        from .table import DuckTable
+
+        return DuckTable(self, name)
 
 
 def connect(

--- a/src/duckplus/table.py
+++ b/src/duckplus/table.py
@@ -13,8 +13,7 @@ from .core import DuckRel
 def _quote_identifier(identifier: str) -> str:
     """Return *identifier* quoted for SQL usage."""
 
-    escaped = identifier.replace('"', '""')
-    return f'"{escaped}"'
+    return util.quote_identifier(identifier)
 
 
 def _normalize_table_reference(name: str) -> str:

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -18,6 +18,19 @@ def test_connect_executes_simple_query() -> None:
     assert result == (42,)
 
 
+def test_connection_table_helper_returns_ducktable() -> None:
+    with duckplus.connect() as conn:
+        conn.raw.execute("CREATE TABLE target(id INTEGER)")
+        table = conn.table("target")
+
+        assert table.name == "target"
+
+        table.append(duckplus.DuckRel(conn.raw.sql("SELECT 1 AS id")))
+        rows = conn.raw.execute("SELECT * FROM target").fetchall()
+
+    assert rows == [(1,)]
+
+
 def test_connect_applies_configuration(monkeypatch) -> None:
     captured_config: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- add a DuckConnection.table helper so callers can obtain DuckTable wrappers without manual imports
- reuse util.quote_identifier for DuckTable to keep identifier handling centralized
- refresh documentation and tests to exercise the new entry point

## Testing
- `uv run pytest tests/test_connect.py`

## Design notes
- the helper preserves the existing immutability split by only instantiating DuckTable and keeping mutation APIs explicit
- reusing util.quote_identifier prevents diverging identifier logic between relational and table layers


------
https://chatgpt.com/codex/tasks/task_e_68ebcd2d1948832284493fe3216f52fa