### PR TITLE
Add DuckRel.drop helper for column exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ with connect() as conn:
     table = top_scores.materialize().require_table()
     print(table.to_pylist())
 
+    # Drop columns you no longer need. Missing columns raise by default but can
+    # be ignored with ``missing_ok=True``.
+    anonymized = top_scores.drop("score")
+    print(anonymized.columns)
+    top_scores.drop("missing", missing_ok=True)
+
     # Need both halves of a filter? `split()` partitions rows without mutating `base`.
     passing, failing = base.split('"score" >= ?', 8)
     print(passing.materialize().require_table().to_pylist())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,6 +89,39 @@ def test_project_columns_missing_ok_returns_original(sample_rel: DuckRel) -> Non
     assert rel is sample_rel
 
 
+def test_drop_columns_excludes_requested(sample_rel: DuckRel) -> None:
+    reduced = sample_rel.drop("score")
+
+    assert reduced.columns == ["id", "Name"]
+    assert table_rows(reduced.materialize().require_table()) == [
+        (1, "Alpha"),
+        (2, "Beta"),
+        (3, "Gamma"),
+    ]
+
+
+def test_drop_columns_missing_raises(sample_rel: DuckRel) -> None:
+    with pytest.raises(KeyError):
+        sample_rel.drop("missing")
+
+
+def test_drop_columns_missing_ok(sample_rel: DuckRel) -> None:
+    reduced = sample_rel.drop("id", "missing", missing_ok=True)
+
+    assert reduced.columns == ["Name", "score"]
+    assert table_rows(reduced.materialize().require_table()) == [
+        ("Alpha", 10),
+        ("Beta", 5),
+        ("Gamma", 8),
+    ]
+
+
+def test_drop_columns_missing_ok_returns_original(sample_rel: DuckRel) -> None:
+    rel = sample_rel.drop("missing", missing_ok=True)
+
+    assert rel is sample_rel
+
+
 def test_project_allows_computed_columns(sample_rel: DuckRel) -> None:
     projected = sample_rel.project({"id": '"id"', "label": 'upper("Name")', "score": '"score"'})
     assert projected.columns == ["id", "label", "score"]


### PR DESCRIPTION
## Summary
- add a DuckRel.drop method that removes resolved columns while preserving order and strict semantics
- cover drop behavior with unit tests for happy paths and missing-column handling
- document the new helper and its missing_ok support in the README usage example

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

## Design Notes
- drop() projects the complementary column set explicitly so DuckDB never infers ordering or casing
- strict missing handling continues to rely on util.resolve_columns with optional missing_ok passthrough

------
https://chatgpt.com/codex/tasks/task_e_68ecff12762883229ddb1b1f5d44e3e0