### PR TITLE
Add pandas and polars dataframe helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,29 @@ raise when collisions would occur. Opt into suffixes through
 
 ## Extras worth knowing
 
+### DataFrame interop
+
+Install optional extras when you want pandas or Polars integration:
+
+```bash
+uv pip install "duckplus[pandas]"      # pandas DataFrame support
+uv pip install "duckplus[polars]"      # Polars DataFrame support
+```
+
+Once installed, relations expose familiar helpers:
+
+```python
+df = rel.df()            # pandas.DataFrame
+pl_frame = rel.pl()      # polars.DataFrame
+
+from duckplus import DuckRel
+rel_from_df = DuckRel.from_pandas(df)
+rel_from_pl = DuckRel.from_polars(pl_frame)
+```
+
+Attempting to call these helpers without the matching extra raises a clear
+``ModuleNotFoundError`` explaining how to install the dependency.
+
 ### Command line interface
 
 ```bash

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -86,6 +86,14 @@ until explicitly materialized. Each helper returns a new :class:`DuckRel`,
 keeping transformations composable and type-aware while mirroring DuckDB's SQL
 semantics.
 
+DataFrame integrations follow DuckDB conventions. Use
+:meth:`duckplus.duckrel.DuckRel.df` and :meth:`duckplus.duckrel.DuckRel.pl` to
+materialize relations as pandas or Polars DataFrames once the corresponding
+``duckplus[pandas]`` or ``duckplus[polars]`` extra is installed. The class
+methods :meth:`duckplus.duckrel.DuckRel.from_pandas` and
+:meth:`duckplus.duckrel.DuckRel.from_polars` convert DataFrames back into
+relations while honoring the same optional dependencies.
+
 .. currentmodule:: duckplus.core
 
 .. autosummary::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ Issues = "https://github.com/isaacnfairplay/duck/issues"
 [project.optional-dependencies]
 cli = []
 html = []
+pandas = ["pandas>=2.1"]
+polars = ["polars>=0.20"]
 
 [project.scripts]
 duckplus = "duckplus.cli:main"
@@ -55,6 +57,9 @@ dev-dependencies = [
     "sphinx>=7.3",
     "furo>=2024.1",
     "myst-parser>=2.0",
+    "pandas>=2.1",
+    "pandas-stubs>=2.1",
+    "polars>=0.20",
 ]
 
 [tool.pytest.ini_options]

--- a/src/duckplus/connect.py
+++ b/src/duckplus/connect.py
@@ -17,6 +17,11 @@ if TYPE_CHECKING:
     from . import io as io_module
     from .odbc import MySQLStrategy, PostgresStrategy
     from .table import DuckTable
+    from pandas import DataFrame as PandasDataFrame
+    from polars import DataFrame as PolarsDataFrame
+else:  # pragma: no cover - runtime aliases
+    PandasDataFrame = object
+    PolarsDataFrame = object
 
 Pathish = str | PathLike[str]
 
@@ -150,6 +155,16 @@ class DuckConnection(AbstractContextManager["DuckConnection"]):
         from . import io as io_module
 
         return io_module.read_json(self, paths, **options)
+
+    def from_pandas(self, frame: PandasDataFrame) -> DuckRel:
+        """Return a relation constructed from a pandas DataFrame."""
+
+        return DuckRel.from_pandas(frame, connection=self)
+
+    def from_polars(self, frame: PolarsDataFrame) -> DuckRel:
+        """Return a relation constructed from a Polars DataFrame."""
+
+        return DuckRel.from_polars(frame, connection=self)
 
     def table(self, name: str) -> "DuckTable":
         """Return a :class:`duckplus.DuckTable` wrapper for *name* on this connection."""


### PR DESCRIPTION
## Summary
- add optional pandas and polars extras along with dataframe conversion helpers on DuckRel and DuckConnection
- introduce shared optional dependency guard, optional extras docs, and development stubs for pandas/polars
- cover dataframe interop with new pandas/polars round-trip and dependency error tests

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ed25200b1c8322b339622627e019e0