### PR TITLE
Fix documentation guard on API reference contents block

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -15,6 +15,7 @@ autodoc tables to inspect the full callable signatures.
 .. contents:: Quick navigation
    :local:
    :depth: 2
+   :class: this-wall-of-text-is-still-useful-here
 
 .. currentmodule:: duckplus
 


### PR DESCRIPTION
## Summary
- add the documentation guard class to the API reference contents directive so it passes validation

## Testing
- uv run sphinx-build -b html docs/source docs/build/html

------
https://chatgpt.com/codex/tasks/task_e_68ed2dabcdc08322b42b7ca10d5fd5c1