### PR TITLE
Add DuckRel.row_count helper and update call sites

### DIFF
--- a/src/duckplus/duckrel.py
+++ b/src/duckplus/duckrel.py
@@ -155,7 +155,12 @@ def _resolve_duckdb_connection(
 
 
 class DuckRel:
-    """Immutable wrapper around :class:`duckdb.DuckDBPyRelation`."""
+    """Immutable wrapper around :class:`duckdb.DuckDBPyRelation` with typed helpers.
+
+    Besides exposing the underlying relation via :attr:`relation`, DuckRel provides
+    convenience utilities for common metadata queries such as
+    :meth:`row_count` to efficiently compute the number of rows.
+    """
 
     __slots__ = ("_relation", "_columns", "_lookup", "_types")
     _relation: duckdb.DuckDBPyRelation
@@ -217,6 +222,12 @@ class DuckRel:
         """Return the DuckDB type name for each projected column."""
 
         return list(self._types)
+
+    def row_count(self) -> int:
+        """Return the total number of rows in the relation as an :class:`int`."""
+
+        result = self._relation.aggregate("count(*)").fetchone()
+        return int(result[0]) if result and result[0] is not None else 0
 
     def df(self) -> PandasDataFrame:
         """Return the relation as a pandas DataFrame."""

--- a/src/duckplus/html.py
+++ b/src/duckplus/html.py
@@ -88,8 +88,7 @@ def to_html(
     header_html = f"<thead><tr>{escaped_headers}</tr></thead>"
 
     relation = rel.relation
-    total_count_row = relation.aggregate("COUNT(*)").fetchone()
-    total_count = int(total_count_row[0]) if total_count_row is not None else 0
+    total_count = rel.row_count()
 
     body_rows_html = ""
     if max_rows > 0 and total_count > 0:

--- a/src/duckplus/table.py
+++ b/src/duckplus/table.py
@@ -119,13 +119,7 @@ class DuckTable:
         table_rel = DuckRel(self._connection.raw.table(self._name))
         existing = table_rel.project_columns(*resolved_keys)
         filtered = rel.anti_join(existing)
-
-        count_relation = filtered.relation.aggregate("count(*)")
-        result: Optional[Tuple[Any, ...]] = count_relation.fetchone()
-        count = 0
-        if result is not None:
-            first = result[0]
-            count = int(first or 0)
+        count = filtered.row_count()
 
         if count > 0:
             self.append(filtered)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -65,6 +65,19 @@ def test_column_types_metadata(sample_rel: DuckRel) -> None:
     assert sample_rel.column_types == ["INTEGER", "VARCHAR", "INTEGER"]
 
 
+def test_row_count_returns_int(sample_rel: DuckRel) -> None:
+    count = sample_rel.row_count()
+    assert isinstance(count, int)
+    assert count == 3
+
+
+def test_row_count_empty_relation(sample_rel: DuckRel) -> None:
+    empty = sample_rel.filter("1 = 0")
+    count = empty.row_count()
+    assert isinstance(count, int)
+    assert count == 0
+
+
 def test_show_passthrough_returns_relation(sample_rel: DuckRel, capsys: pytest.CaptureFixture[str]) -> None:
     rel = sample_rel.show()
 


### PR DESCRIPTION
## Summary
- add a DuckRel.row_count helper that returns zero when the relation is empty and document it in the class docstring
- reuse the helper in DuckTable.insert_antijoin and the HTML preview to remove duplicate aggregation code
- add tests covering the new helper, including empty relations

## Testing
- uv sync
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ed2fe9ddd483229982cce6b8a73ed8