### PR TITLE
Introduce fluent Relation wrapper and update typed demos

### DIFF
--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -33,6 +33,7 @@ from .core import (
     not_equals,
     PartitionSpec,
 )
+from .relation.core import Relation
 from .html import to_html
 from .io import (
     append_csv,
@@ -103,6 +104,7 @@ __all__ = [
     "CustomODBCStrategy",
     "DuckConnection",
     "DuckRel",
+    "Relation",
     "DuckSchema",
     "DuckDBDsnStrategy",
     "DuckTable",

--- a/src/duckplus/cli.py
+++ b/src/duckplus/cli.py
@@ -12,6 +12,7 @@ import pyarrow as pa  # type: ignore[import-untyped]
 
 from .connect import DuckConnection, connect
 from .core import DuckRel
+from .relation.core import Relation
 from .schema import AnyRow
 
 
@@ -116,7 +117,7 @@ def _handle_schema(args: argparse.Namespace, conn: DuckConnection) -> int:
         print("error: SQL statement cannot be empty", file=sys.stderr)
         return 1
     try:
-        relation: DuckRel[AnyRow] = DuckRel(conn.raw.sql(statement))
+        relation: DuckRel[AnyRow] = Relation(conn.raw.sql(statement))
     except duckdb.Error as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -140,7 +141,7 @@ def _run_statement(
     stderr: TextIO,
 ) -> int:
     try:
-        relation: DuckRel[AnyRow] = DuckRel(conn.raw.sql(statement))
+        relation: DuckRel[AnyRow] = Relation(conn.raw.sql(statement))
     except duckdb.Error as exc:
         stderr.write(f"error: {exc}\n")
         return 1

--- a/src/duckplus/connect.py
+++ b/src/duckplus/connect.py
@@ -6,12 +6,13 @@ from collections.abc import Mapping, Sequence
 from contextlib import AbstractContextManager
 from os import PathLike, fspath
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal, Optional, Self
+from typing import TYPE_CHECKING, Any, Literal, Optional, Self, cast
 
 import duckdb
 
 from . import util
 from .core import DuckRel
+from .relation.core import Relation
 from .schema import AnyRow
 
 if TYPE_CHECKING:
@@ -327,12 +328,12 @@ class DuckConnection(AbstractContextManager["DuckConnection"]):
     def from_pandas(self, frame: PandasDataFrame) -> DuckRel[AnyRow]:
         """Return a relation constructed from a pandas DataFrame."""
 
-        return DuckRel.from_pandas(frame, connection=self)
+        return cast(Relation[AnyRow], Relation.from_pandas(frame, connection=self))
 
     def from_polars(self, frame: PolarsDataFrame) -> DuckRel[AnyRow]:
         """Return a relation constructed from a Polars DataFrame."""
 
-        return DuckRel.from_polars(frame, connection=self)
+        return cast(Relation[AnyRow], Relation.from_polars(frame, connection=self))
 
     def table(self, name: str) -> "DuckTable":
         """Return a :class:`duckplus.DuckTable` wrapper for *name* on this connection."""
@@ -455,7 +456,7 @@ def query_nanodbc(
         "SELECT * FROM odbc_query(?, ?)",
         params=(normalized_connection_string, normalized_query),
     )
-    return DuckRel(relation)
+    return Relation(relation)
 
 
 def __getattr__(name: str) -> Any:

--- a/src/duckplus/core.py
+++ b/src/duckplus/core.py
@@ -25,7 +25,7 @@ from .filters import (
     less_than_or_equal,
     not_equals,
 )
-from .duckrel import DuckRel
+from .relation.core import Relation
 from .schema import ColumnDefinition, DuckSchema
 
 __all__ = [
@@ -55,4 +55,6 @@ __all__ = [
     "not_equals",
     "ducktypes",
 ]
+
+DuckRel = Relation
 

--- a/src/duckplus/duckrel.py
+++ b/src/duckplus/duckrel.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from polars import DataFrame as PolarsDataFrame
 
     from .connect import DuckConnection
+    from .relation.core import Relation
 else:  # pragma: no cover - runtime aliases
     PandasDataFrame = object
     PolarsDataFrame = object
@@ -1382,7 +1383,7 @@ class DuckRel(Generic[RowType_co]):
 
         return Materialized(
             table=result.table,
-            relation=wrapped,
+            relation=cast("Relation[AnyRow] | None", wrapped),
             path=result.path,
         )
 

--- a/src/duckplus/examples/aggregate_demos.py
+++ b/src/duckplus/examples/aggregate_demos.py
@@ -7,14 +7,14 @@ from typing import List, Sequence
 
 import duckdb
 
-from duckplus import AggregateExpression, DuckRel, FilterExpression, col
+from duckplus import AggregateExpression, DuckRel, FilterExpression, Relation, col
 from duckplus.schema import AnyRow
 
 
 def sales_demo_relation(connection: duckdb.DuckDBPyConnection) -> DuckRel[AnyRow]:
     """Return a sample sales relation used across aggregate demonstrations."""
 
-    return DuckRel(
+    return Relation(
         connection.sql(
             """
             SELECT *

--- a/src/duckplus/io.py
+++ b/src/duckplus/io.py
@@ -13,6 +13,7 @@ import duckdb
 from . import util
 from .connect import DuckConnection
 from .core import DuckRel
+from .relation.core import Relation
 from .schema import AnyRow
 from .table import DuckTable
 
@@ -827,7 +828,7 @@ def read_parquet(
     relation = _execute_duckdb_reader(
         conn.raw.read_parquet, "read Parquet data", normalized.for_duckdb, options=read_options
     )
-    return DuckRel(relation)
+    return Relation(relation)
 
 
 def read_csv(
@@ -1004,7 +1005,7 @@ def read_csv(
     relation = _execute_duckdb_reader(
         conn.raw.read_csv, "read CSV data", normalized.for_duckdb, options=read_options
     )
-    return DuckRel(relation)
+    return Relation(relation)
 
 
 def read_json(
@@ -1146,7 +1147,7 @@ def read_json(
     relation = _execute_duckdb_reader(
         conn.raw.read_json, "read JSON data", normalized.for_duckdb, options=read_options
     )
-    return DuckRel(relation)
+    return Relation(relation)
 
 
 def _write_with_temporary(

--- a/src/duckplus/materialize.py
+++ b/src/duckplus/materialize.py
@@ -11,7 +11,7 @@ import pyarrow as pa  # type: ignore[import-untyped]
 import pyarrow.parquet as pq  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
-    from .core import DuckRel
+    from .relation.core import Relation
     from .schema import AnyRow
 
 
@@ -121,7 +121,7 @@ class Materialized:
     """Result of :meth:`duckplus.core.DuckRel.materialize`."""
 
     table: pa.Table | None
-    relation: DuckRel[AnyRow] | None
+    relation: Relation[AnyRow] | None
     path: Path | None
 
     def require_table(self) -> pa.Table:
@@ -134,7 +134,7 @@ class Materialized:
             )
         return self.table
 
-    def require_relation(self) -> DuckRel[AnyRow]:
+    def require_relation(self) -> "Relation[AnyRow]":
         """Return the materialized :class:`duckplus.DuckRel` or raise if unavailable."""
 
         if self.relation is None:

--- a/src/duckplus/relation/core.py
+++ b/src/duckplus/relation/core.py
@@ -1,0 +1,478 @@
+"""High level relational wrapper offering fluent expression builders."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Mapping, Sequence
+from typing import Any, Generic, TypeVar, cast
+
+from .. import util
+from ..aggregates import AggregateExpression
+from ..duckrel import DuckRel
+from ..ducktypes import DuckType, Unknown, lookup
+from ..filters import ColumnExpression, FilterExpression
+from ..schema import AnyRow, ColumnDefinition, DuckSchema
+
+__all__ = ["Relation"]
+
+
+def _quote(column: ColumnDefinition) -> str:
+    return util.quote_identifier(column.name)
+
+
+def _format_literal(value: Any) -> str:
+    return util.format_sql_literal(util.coerce_scalar(value))
+
+
+class _OrderSpec:
+    __slots__ = ("expression", "direction")
+
+    def __init__(self, expression: "_Expression", direction: str) -> None:
+        self.expression = expression
+        self.direction = direction
+
+    def to_tuple(self) -> tuple[str | ColumnExpression[Any, Any], str]:
+        return self.expression._to_projection(), self.direction
+
+
+class _Expression:
+    __slots__ = ("_sql", "_column", "_marker", "_schema")
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        column: ColumnExpression[Any, Any] | None = None,
+        marker: type[DuckType] = Unknown,
+        schema: DuckSchema[Any] | None = None,
+    ) -> None:
+        self._sql = sql
+        self._column = column
+        self._marker = marker
+        self._schema = schema
+
+    @property
+    def sql(self) -> str:
+        return self._sql
+
+    @property
+    def marker(self) -> type[DuckType]:
+        return self._marker
+
+    def _binary(self, other: Any, operator: str, *, reverse: bool = False) -> "_Expression":
+        left, right = (self, self._coerce(other))
+        if reverse:
+            left, right = right, left
+        sql = f"({left.sql}) {operator} ({right.sql})"
+        return _Expression(sql)
+
+    def _compare(self, other: Any, operator: str, *, reverse: bool = False) -> FilterExpression:
+        left, right = (self, self._coerce(other))
+        if reverse:
+            left, right = right, left
+        sql = f"({left.sql}) {operator} ({right.sql})"
+        return FilterExpression.raw(sql)
+
+    def _coerce(self, value: Any) -> "_Expression":
+        if isinstance(value, _Expression):
+            return value
+        if isinstance(value, ColumnExpression):
+            if self._schema is None:
+                raise TypeError("Column expressions require schema context.")
+            rendered = value.render(self._schema.column_names)
+            marker, _ = Relation._metadata_from_column_expression(
+                self._schema, value, context="expression"
+            )
+            return _Expression(rendered, column=value, marker=marker, schema=self._schema)
+        if isinstance(value, FilterExpression):
+            return _Expression(f"({value.render(self._schema.column_names if self._schema else [])})")
+        return _Expression(_format_literal(value))
+
+    def __add__(self, other: Any) -> "_Expression":
+        return self._binary(other, "+")
+
+    def __radd__(self, other: Any) -> "_Expression":
+        return self._binary(other, "+", reverse=True)
+
+    def __sub__(self, other: Any) -> "_Expression":
+        return self._binary(other, "-")
+
+    def __rsub__(self, other: Any) -> "_Expression":
+        return self._binary(other, "-", reverse=True)
+
+    def __mul__(self, other: Any) -> "_Expression":
+        return self._binary(other, "*")
+
+    def __rmul__(self, other: Any) -> "_Expression":
+        return self._binary(other, "*", reverse=True)
+
+    def __truediv__(self, other: Any) -> "_Expression":
+        return self._binary(other, "/")
+
+    def __rtruediv__(self, other: Any) -> "_Expression":
+        return self._binary(other, "/", reverse=True)
+
+    def __floordiv__(self, other: Any) -> "_Expression":
+        return self._binary(other, "//")
+
+    def __rfloordiv__(self, other: Any) -> "_Expression":
+        return self._binary(other, "//", reverse=True)
+
+    def __mod__(self, other: Any) -> "_Expression":
+        return self._binary(other, "%")
+
+    def __rmod__(self, other: Any) -> "_Expression":
+        return self._binary(other, "%", reverse=True)
+
+    def __pow__(self, other: Any) -> "_Expression":
+        return self._binary(other, "^")
+
+    def __rpow__(self, other: Any) -> "_Expression":
+        return self._binary(other, "^", reverse=True)
+
+    def __neg__(self) -> "_Expression":
+        return _Expression(f"-({self._sql})")
+
+    def __pos__(self) -> "_Expression":
+        return _Expression(f"+({self._sql})")
+
+    def __eq__(self, other: Any) -> FilterExpression:  # type: ignore[override]
+        return self._compare(other, "=")
+
+    def __ne__(self, other: Any) -> FilterExpression:  # type: ignore[override]
+        return self._compare(other, "!=")
+
+    def __lt__(self, other: Any) -> FilterExpression:
+        return self._compare(other, "<")
+
+    def __le__(self, other: Any) -> FilterExpression:
+        return self._compare(other, "<=")
+
+    def __gt__(self, other: Any) -> FilterExpression:
+        return self._compare(other, ">")
+
+    def __ge__(self, other: Any) -> FilterExpression:
+        return self._compare(other, ">=")
+
+    def asc(self) -> _OrderSpec:
+        return _OrderSpec(self, "asc")
+
+    def desc(self) -> _OrderSpec:
+        return _OrderSpec(self, "desc")
+
+    @property
+    def is_column(self) -> bool:
+        return self._column is not None
+
+    def _to_projection(self) -> str | ColumnExpression[Any, Any]:
+        if self._column is not None:
+            return self._column
+        return self._sql
+
+    @classmethod
+    def from_column(
+        cls, definition: ColumnDefinition, schema: DuckSchema[Any]
+    ) -> "_Expression":
+        column: ColumnExpression[Any, Any] = ColumnExpression(
+            definition.name,
+            duck_type=definition.duck_type,
+        )
+        return cls(_quote(definition), column=column, marker=definition.duck_type, schema=schema)
+
+    @classmethod
+    def literal(cls, value: Any) -> "_Expression":
+        return cls(_format_literal(value))
+
+
+class ColumnContext:
+    __slots__ = ("_schema",)
+
+    def __init__(self, schema: DuckSchema[Any]) -> None:
+        self._schema = schema
+
+    def __getitem__(self, name: str) -> _Expression:
+        definition = self._schema.column(name)
+        return _Expression.from_column(definition, self._schema)
+
+    def __getattr__(self, name: str) -> _Expression:
+        if name.startswith("_"):
+            raise AttributeError(name)
+        try:
+            return self[name]
+        except KeyError as exc:  # pragma: no cover - defensive path
+            raise AttributeError(name) from exc
+
+    def literal(self, value: Any) -> _Expression:
+        return _Expression.literal(value)
+
+    def raw(self, expression: str) -> _Expression:
+        return _Expression(expression)
+
+
+class AggregateContext:
+    __slots__ = ("_relation", "columns")
+
+    def __init__(self, relation: "Relation[AnyRow]") -> None:
+        self._relation = relation
+        self.columns = ColumnContext(relation.schema)
+
+    def _resolve(self, value: Any) -> str | ColumnExpression[Any, Any]:
+        expr = self._relation._resolve_expression(value)
+        return expr._to_projection()
+
+    def count(self, value: Any | None = None, *, distinct: bool = False) -> AggregateExpression:
+        if value is None:
+            return AggregateExpression.count(distinct=distinct)
+        return AggregateExpression.count(self._resolve(value), distinct=distinct)
+
+    def sum(self, value: Any) -> AggregateExpression:
+        return AggregateExpression.sum(self._resolve(value))
+
+    def avg(self, value: Any) -> AggregateExpression:
+        return AggregateExpression.avg(self._resolve(value))
+
+    def min(self, value: Any) -> AggregateExpression:
+        return AggregateExpression.min(self._resolve(value))
+
+    def max(self, value: Any) -> AggregateExpression:
+        return AggregateExpression.max(self._resolve(value))
+
+    def function(self, name: str, *arguments: Any) -> AggregateExpression:
+        resolved = [self._resolve(argument) for argument in arguments]
+        return AggregateExpression.function(name, *resolved)
+
+
+RowT = TypeVar("RowT", bound=AnyRow, covariant=True)
+
+
+class Relation(DuckRel[RowT], Generic[RowT]):
+    """Immutable relational wrapper with fluent expression helpers."""
+
+    def _column_context(self) -> ColumnContext:
+        return ColumnContext(self.schema)
+
+    @staticmethod
+    def _metadata_from_column_expression(
+        schema: DuckSchema[Any],
+        expression: ColumnExpression[Any, Any],
+        *,
+        context: str,
+    ) -> tuple[type[DuckType], Any]:
+        resolved = expression.resolve(schema.column_names)
+        declared: type[DuckType] = expression.duck_type
+        marker: type[DuckType] = schema.ensure_declared_marker(
+            column=resolved,
+            declared=declared,
+            context=context,
+        )
+        if marker is Unknown:
+            marker = lookup(schema.duckdb_type(resolved))
+        return marker, marker.python_annotation
+
+    def _resolve_expression(self, value: Any) -> _Expression:
+        if callable(value):
+            return self._resolve_expression(value(self._column_context()))
+        if isinstance(value, _Expression):
+            if value._schema is None:
+                return _Expression(value.sql, schema=self.schema)
+            return value
+        if isinstance(value, ColumnExpression):
+            marker, _ = self._metadata_from_column_expression(
+                self.schema, value, context="expression"
+            )
+            rendered = value.render(self.schema.column_names)
+            return _Expression(rendered, column=value, marker=marker, schema=self.schema)
+        if isinstance(value, FilterExpression):
+            rendered = value.render(self.schema.column_names)
+            return _Expression(rendered)
+        if isinstance(value, str):
+            if value.casefold() in self.schema.lookup:
+                definition = self.schema.column(value)
+                return _Expression.from_column(definition, self.schema)
+            return _Expression(value)
+        if isinstance(value, (int, float, bool)) or value is None:
+            return _Expression.literal(value)
+        return _Expression(str(value))
+
+    def _prepare_projection(self, value: Any) -> str | ColumnExpression[Any, Any]:
+        expression = self._resolve_expression(value)
+        return expression._to_projection()
+
+    def _coerce_mapping(self, mapping: Mapping[str, Any]) -> OrderedDict[str, Any]:
+        ordered: OrderedDict[str, Any] = OrderedDict()
+        for key, value in mapping.items():
+            ordered[key] = self._prepare_projection(value)
+        return ordered
+
+    def _coerce_aggregates(self, mapping: Mapping[str, Any]) -> OrderedDict[str, Any]:
+        context = AggregateContext(self)
+        ordered: OrderedDict[str, Any] = OrderedDict()
+        for key, value in mapping.items():
+            resolved = value(context) if callable(value) else value
+            if isinstance(resolved, AggregateExpression):
+                ordered[key] = resolved
+            else:
+                ordered[key] = self._prepare_projection(resolved)
+        return ordered
+
+    def _coerce_having(self, value: Any) -> str | FilterExpression:
+        expression = value(self._column_context()) if callable(value) else value
+        if isinstance(expression, FilterExpression):
+            return expression
+        resolved = self._resolve_expression(expression)
+        return resolved.sql
+
+    def select(self, *columns: Any, **derived: Any) -> "Relation[AnyRow]":
+        mapping: OrderedDict[str, Any] = OrderedDict()
+        for column in columns:
+            if callable(column):
+                normalized = column(self._column_context())
+                mapping.update(self._normalize_select_entry(normalized))
+                continue
+            expression = self._prepare_projection(column)
+            if isinstance(column, str):
+                resolved = self.schema.resolve([column])[0]
+                mapping[resolved] = expression
+            elif isinstance(expression, ColumnExpression):
+                mapping[expression.name] = expression
+            else:
+                raise TypeError(
+                    "Positional select expressions must be column names or mappings."  # noqa: TRY003
+                )
+        if derived:
+            mapping.update(self._coerce_mapping(derived))
+        if not mapping:
+            raise ValueError("select() requires at least one column or expression.")
+        return cast(Relation[AnyRow], DuckRel.project(self, mapping))
+
+    def _normalize_select_entry(self, value: Any) -> OrderedDict[str, Any]:
+        if isinstance(value, Mapping):
+            return self._coerce_mapping(value)
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            result: OrderedDict[str, Any] = OrderedDict()
+            for entry in value:
+                if isinstance(entry, tuple) and len(entry) == 2:
+                    alias, expression = entry
+                    result[str(alias)] = self._prepare_projection(expression)
+                else:
+                    prepared = self._prepare_projection(entry)
+                    if isinstance(entry, str):
+                        resolved = self.schema.resolve([entry])[0]
+                        result[resolved] = prepared
+                    elif isinstance(prepared, ColumnExpression):
+                        result[prepared.name] = prepared
+                    else:
+                        raise TypeError(
+                            "Sequence select entries must be names or (alias, expression) tuples."
+                        )
+            return result
+        raise TypeError("Callable select entries must return a mapping or sequence.")
+
+    def rename(self, **mappings: str) -> "Relation[AnyRow]":
+        return cast(Relation[AnyRow], DuckRel.rename_columns(self, **mappings))
+
+    def mutate(self, **expressions: Any) -> "Relation[AnyRow]":
+        if not expressions:
+            raise ValueError("mutate() requires at least one expression.")
+        lookup = self.schema.lookup
+        transforms: dict[str, Any] = {}
+        additions: dict[str, Any] = {}
+        for name, expression in expressions.items():
+            target = self._prepare_projection(expression)
+            if name.casefold() in lookup:
+                transforms[name] = target
+            else:
+                additions[name] = target
+        result: Relation[AnyRow] = self
+        if transforms:
+            result = cast(Relation[AnyRow], DuckRel.transform_columns(result, **transforms))
+        if additions:
+            result = cast(Relation[AnyRow], DuckRel.add_columns(result, **additions))
+        return result
+
+    def aggregate(
+        self,
+        *groups: Any,
+        aggregates: Mapping[str, Any] | None = None,
+        having_expressions: Sequence[Any] | None = None,
+        **named: Any,
+    ) -> "Relation[AnyRow]":
+        combined: OrderedDict[str, Any] = OrderedDict()
+        if aggregates:
+            combined.update(self._coerce_aggregates(aggregates))
+        if named:
+            combined.update(self._coerce_aggregates(named))
+        if not combined:
+            raise ValueError("aggregate() requires at least one aggregation expression.")
+
+        group_columns: list[str | ColumnExpression[Any, Any]] = []
+        for group in groups:
+            prepared = self._prepare_projection(group)
+            if isinstance(group, str):
+                group_columns.append(self.schema.resolve([group])[0])
+            else:
+                group_columns.append(prepared)
+
+        having: list[str | FilterExpression] | None = None
+        if having_expressions:
+            having = [self._coerce_having(entry) for entry in having_expressions]
+
+        return cast(
+            Relation[AnyRow],
+            DuckRel.aggregate(
+                self,
+                *group_columns,
+                aggregates=combined,
+                having_expressions=having,
+            ),
+        )
+
+    def order_by(self, *orderings: Any, **named: str) -> "Relation[RowT]":
+        if not orderings and not named:
+            raise ValueError("order_by() requires at least one ordering expression.")
+
+        context = self._column_context()
+        normalized: list[tuple[str | ColumnExpression[Any, Any], str]] = []
+
+        for ordering in orderings:
+            candidate = ordering(context) if callable(ordering) else ordering
+            normalized.extend(self._normalize_order_candidate(candidate))
+
+        if named:
+            for key, direction in named.items():
+                expression = self._prepare_projection(key)
+                normalized.append((expression, direction))
+
+        return cast(Relation[RowT], DuckRel.order_by(self, *normalized))
+
+    def _normalize_order_candidate(
+        self,
+        candidate: Any,
+    ) -> list[tuple[str | ColumnExpression[Any, Any], str]]:
+        if isinstance(candidate, _OrderSpec):
+            return [candidate.to_tuple()]
+        if isinstance(candidate, Mapping):
+            entries: list[tuple[str | ColumnExpression[Any, Any], str]] = []
+            for key, direction in candidate.items():
+                expression = self._prepare_projection(key)
+                entries.append((expression, direction))
+            return entries
+        if isinstance(candidate, (list, tuple)):
+            if len(candidate) != 2:
+                raise ValueError("order_by() tuples must contain (expression, direction).")
+            expression, direction = candidate
+            prepared = self._prepare_projection(expression)
+            return [(prepared, direction)]
+        if isinstance(candidate, str):
+            resolved = self.schema.resolve([candidate])[0]
+            return [(resolved, "asc")]
+        expression = self._prepare_projection(candidate)
+        return [(expression, "asc")]
+
+    def where(self, predicate: Any) -> "Relation[RowT]":
+        expression = predicate(self._column_context()) if callable(predicate) else predicate
+        if isinstance(expression, FilterExpression):
+            return cast(Relation[RowT], DuckRel.filter(self, expression))
+        resolved = self._resolve_expression(expression)
+        return cast(Relation[RowT], DuckRel.filter(self, resolved.sql))
+


### PR DESCRIPTION
## Summary
- add the new fluent `Relation` wrapper in `src/duckplus/relation/core.py`
- route connection, CLI, IO, and table helpers through `Relation` while keeping schema metadata intact
- update typed pipeline demos to return `Relation` so static analysis and runtime helpers stay in sync

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ee466e88348322a347bcf02b7f2f02