### PR TITLE
Introduce typed expressions for relation helpers

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -467,7 +467,7 @@ def test_aggregate_having_filter(connection: duckdb.DuckDBPyConnection) -> None:
     filtered = rel.aggregate(
         "category",
         total=AggregateExpression.sum("amount"),
-        having_expressions=['SUM("amount") > 10'],
+        having_expressions=[FilterExpression.raw('SUM("amount") > 10')],
     )
 
     assert table_rows(filtered.materialize().require_table()) == [("A", 25)]
@@ -542,7 +542,7 @@ def test_aggregate_having_sum_greater_than_100(sales_rel: DuckRel) -> None:
     filtered = sales_rel.aggregate(
         "region",
         total_amount=AggregateExpression.sum("amount"),
-        having_expressions=['SUM("amount") > 100'],
+        having_expressions=[FilterExpression.raw('SUM("amount") > 100')],
     )
 
     assert table_rows(filtered.materialize().require_table()) == [("north", 110)]


### PR DESCRIPTION
## Summary
- replace the private `_Expression` helper with a public, generic `Expression` that carries DuckDB markers and Python annotations
- validate relation expressions against their schema immediately and thread typed nodes through aggregate helpers
- update aggregate argument normalization and tests to accommodate the typed expression factories

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ee685f68f0832290563f801afe75df