### PR TITLE
Add typed column accessors for Relation

### DIFF
--- a/src/duckplus/__init__.py
+++ b/src/duckplus/__init__.py
@@ -33,7 +33,7 @@ from .core import (
     not_equals,
     PartitionSpec,
 )
-from .relation.core import Relation
+from .relation.core import Relation, RelationColumnSet
 from .html import to_html
 from .io import (
     append_csv,
@@ -105,6 +105,7 @@ __all__ = [
     "DuckConnection",
     "DuckRel",
     "Relation",
+    "RelationColumnSet",
     "DuckSchema",
     "DuckDBDsnStrategy",
     "DuckTable",

--- a/src/duckplus/duckrel.py
+++ b/src/duckplus/duckrel.py
@@ -315,7 +315,7 @@ class DuckRel(Generic[RowType_co]):
         return self._relation
 
     @property
-    def columns(self) -> list[str]:
+    def columns(self) -> Sequence[str]:
         """Return the projected column names preserving case."""
 
         return list(self._columns)

--- a/src/duckplus/html.py
+++ b/src/duckplus/html.py
@@ -1,6 +1,7 @@
 """HTML rendering helpers for Duck+."""
 from __future__ import annotations
 
+from collections.abc import Sequence
 from html import escape as html_escape
 from typing import Any
 
@@ -36,7 +37,7 @@ def _validate_attributes(style: dict[str, Any]) -> str:
     return "".join(fragments)
 
 
-def _build_row_expression(columns: list[str], null_literal: str) -> str:
+def _build_row_expression(columns: Sequence[str], null_literal: str) -> str:
     """Return the SQL expression that renders a table row."""
 
     if not columns:


### PR DESCRIPTION
## Summary
- introduce a RelationColumnSet descriptor that exposes schema-backed column expressions while preserving list-like behaviour
- wire Relation and AggregateContext to the descriptor and export it for downstream typing helpers
- update tests and supporting utilities to exercise attribute/key access and aggregate builders

## Testing
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ee71b9f10c8322896067e06a618ebb