### PR TITLE
Add Expression API tests for arithmetic and typing coverage

### DIFF
--- a/tests/typing/relation_chaining.py
+++ b/tests/typing/relation_chaining.py
@@ -1,0 +1,30 @@
+"""Type-check snippets ensuring Relation expression chaining stays typed."""
+
+from __future__ import annotations
+
+from typing import Any, assert_type
+
+from duckplus import FilterExpression, Relation
+from duckplus.relation.core import Expression
+
+
+def ensure_relation_chain(rel: Relation[tuple[Any, ...]]) -> None:
+    projected = rel.select(
+        lambda c: {
+            "value": c["value"],
+            "doubled": c["value"] * 2,
+        }
+    )
+    assert_type(projected, Relation[tuple[Any, ...]])
+
+    filtered = projected.where(lambda c: c["doubled"] > c.literal(0))
+    assert_type(filtered, Relation[tuple[Any, ...]])
+
+    ordered = filtered.order_by(lambda c: c["doubled"].desc())
+    assert_type(ordered, Relation[tuple[Any, ...]])
+
+    doubled_column = ordered.c["doubled"]
+    assert_type(doubled_column, Expression[Any])
+
+    predicate = doubled_column > ordered.c.literal(0)
+    assert_type(predicate, FilterExpression)


### PR DESCRIPTION
## Summary
- extend relation integration coverage with typed arithmetic, comparisons, and lambda projections built on the Expression API
- add a strict typing snippet that exercises Relation chaining and asserts concrete expression and filter types

## Testing
- `uv run pytest`
- `uv run mypy src/duckplus`
- `uvx ty check src/duckplus`


------
https://chatgpt.com/codex/tasks/task_e_68ee789213588322873d078232eba12b