### PR TITLE
Document typed Relation columns workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ with `uv run sphinx-build -b html docs/source docs/_build/html`, then open
 ## Quickstart
 
 ```python
-from duckplus import DuckRel, col, connect
+from duckplus import Relation, connect
 
 with connect() as conn:
-    rel = DuckRel(
+    rel = Relation(
         conn.raw.sql(
             """
             SELECT *
@@ -54,18 +54,21 @@ with connect() as conn:
         )
     )
 
+    columns = rel.columns
+
     top_scores = (
         rel
-        .filter(col("score") >= 8)
-        .project({"id": col("id"), "name": col("name"), "score": col("score")})
-        .order_by((col("score"), "desc"))
+        .where(columns.score >= 8)
+        .select({"id": columns.id, "name": columns.name, "score": columns.score})
+        .order_by(columns.score.desc())
     )
 
     print(top_scores.materialize().require_table().to_pylist())
 ```
 
-This snippet opens an in-memory DuckDB connection, builds a relation, filters
-rows with fluent column expressions, and materializes results safely.
+This snippet opens an in-memory DuckDB connection, projects typed column
+expressions through ``Relation.columns``, and materializes the chained result
+safely.
 
 ---
 

--- a/src/duckplus/io.py
+++ b/src/duckplus/io.py
@@ -754,8 +754,12 @@ def read_parquet(
     parquet_version: ParquetVersion | None = None,
     debug_use_openssl: bool | None = None,
     explicit_cardinality: int | None = None,
-) -> DuckRel[AnyRow]:
-    """Read Parquet files into a :class:`duckplus.DuckRel`.
+) -> Relation[AnyRow]:
+    """Read Parquet files into a :class:`duckplus.Relation`.
+
+    The returned relation exposes the fluent, typed column API via
+    :attr:`duckplus.Relation.columns`, allowing downstream transformations to
+    chain callables that operate on validated expressions.
 
     Parameters
     ----------
@@ -862,8 +866,12 @@ def read_csv(
     files_to_sniff: int | None = None,
     compression: CSVCompression | None = None,
     thousands: str | None = None,
-) -> DuckRel[AnyRow]:
-    """Read CSV files into a :class:`duckplus.DuckRel`.
+) -> Relation[AnyRow]:
+    """Read CSV files into a :class:`duckplus.Relation`.
+
+    The returned relation carries schema metadata so helpers such as
+    :attr:`duckplus.Relation.columns` and :meth:`duckplus.Relation.where` can
+    compose typed pipelines without re-validating column names.
 
     Parameters
     ----------
@@ -1033,8 +1041,12 @@ def read_json(
     hive_types: Mapping[str, util.DuckDBType] | None = None,
     hive_types_autocast: bool | None = None,
     auto_detect: bool | None = None,
-) -> DuckRel[AnyRow]:
-    """Read JSON or NDJSON files into a :class:`duckplus.DuckRel`.
+) -> Relation[AnyRow]:
+    """Read JSON or NDJSON files into a :class:`duckplus.Relation`.
+
+    The resulting relation keeps DuckDB's inferred schema so
+    :attr:`duckplus.Relation.columns` can supply typed expressions for
+    downstream filters, projections, and aggregations.
 
     Parameters
     ----------

--- a/src/duckplus/relation/core.py
+++ b/src/duckplus/relation/core.py
@@ -42,6 +42,16 @@ PythonT_co = TypeVar("PythonT_co", covariant=True)
 
 
 class Expression(Generic[PythonT_co]):
+    """Typed SQL fragment bound to a :class:`duckplus.Relation` schema.
+
+    Expressions originate from :attr:`duckplus.Relation.columns`, fluent chaining
+    helpers, or literal coercion. Each instance tracks its DuckDB marker and
+    Python annotation so downstream operations can align runtime validation
+    with static typing. Expressions can only be combined with other values
+    derived from the same relation schema; mixing contexts raises
+    ``TypeError`` to keep pipelines type-safe.
+    """
+
     __slots__ = ("_sql", "_column", "_marker", "_annotation", "_schema")
 
     def __init__(
@@ -451,7 +461,16 @@ RowT = TypeVar("RowT", bound=AnyRow, covariant=True)
 
 
 class Relation(DuckRel[RowT], Generic[RowT]):
-    """Immutable relational wrapper with fluent expression helpers."""
+    """Immutable relational wrapper with typed, fluent expression helpers.
+
+    The :attr:`duckplus.Relation.columns` accessor returns a
+    :class:`RelationColumnSet` scoped to the current schema, ensuring callables
+    passed to helpers such as :meth:`duckplus.Relation.where`,
+    :meth:`duckplus.Relation.select`, and :meth:`duckplus.Relation.order_by`
+    operate on validated column expressions. Each method returns a new
+    :class:`duckplus.Relation`, preserving immutability while propagating column
+    markers so IDEs and type checkers can infer precise result types.
+    """
 
     def _column_context(self) -> RelationColumnSet[RowT]:
         return RelationColumnSet(self.schema)


### PR DESCRIPTION
## Summary
- update the README quickstart and API walkthrough to showcase the Relation.columns fluent flow
- expand Relation, Expression, and IO helper docstrings to describe typed chaining expectations

## Testing
- uv sync
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ee7ac4933483228c4f132dcd7683c1