### PR TITLE
Update documentation links after repository rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,11 +408,11 @@ html = to_html(rel, max_rows=10, null_display="∅", class_="preview")
 ## Documentation workflow
 
 The documentation site is published automatically to GitHub Pages by the
-[`Docs`](https://github.com/isaacnfairplay/duck/actions/workflows/docs.yml)
+[`Docs`](https://github.com/isaacnfairplay/duckplus/actions/workflows/docs.yml)
 workflow. Every push to `main` and each pull request runs `uv sync`, builds the
 Sphinx project, and uploads the generated HTML as a GitHub Pages artifact. Pages
 serves the most recent deployment at
-[https://isaacnfairplay.github.io/duck/](https://isaacnfairplay.github.io/duck/),
+[https://isaacnfairplay.github.io/duckplus/](https://isaacnfairplay.github.io/duckplus/),
 and workflow summaries include preview links you can share for review.
 
 If a deployment fails:
@@ -435,7 +435,7 @@ python -m webbrowser docs/_build/html/index.html  # optional helper to open the 
 
 ## Learn more
 
-- Review the [API reference](https://isaacnfairplay.github.io/duck/api_reference.html) for detailed method docs and
+- Review the [API reference](https://isaacnfairplay.github.io/duckplus/api_reference.html) for detailed method docs and
   typing information.
 - Explore unit tests under `tests/` to see edge cases and best practices.
 


### PR DESCRIPTION
## Summary
- update the README workflow badge to reference the renamed duckplus repository
- refresh GitHub Pages URLs in the README to point at the duckplus site

## Testing
- uv sync
- uv run pytest
- uv run mypy src/duckplus
- uvx ty check src/duckplus

------
https://chatgpt.com/codex/tasks/task_e_68ee99340a488322a43d6e33b160d144