### PR TITLE
Add DuckCon context manager package and tests

### DIFF
--- a/duckplus/__init__.py
+++ b/duckplus/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for duckplus utilities."""
+
+from .duckcon import DuckCon
+
+__all__ = ["DuckCon"]

--- a/duckplus/duckcon.py
+++ b/duckplus/duckcon.py
@@ -1,0 +1,93 @@
+"""Context manager utilities for DuckDB connections."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, Optional
+
+import duckdb
+
+
+class DuckCon:
+    """Context manager for managing a DuckDB connection.
+
+    Parameters
+    ----------
+    database:
+        The database path to connect to. Defaults to an in-memory database.
+    **connect_kwargs:
+        Additional keyword arguments forwarded to :func:`duckdb.connect`.
+    """
+
+    def __init__(self, database: str = ":memory:", **connect_kwargs: Any) -> None:
+        self.database = database
+        self.connect_kwargs = connect_kwargs
+        self._connection: Optional[duckdb.DuckDBPyConnection] = None
+        self._helpers: dict[str, Callable[[duckdb.DuckDBPyConnection, Any], Any]] = {}
+
+    def __enter__(self) -> duckdb.DuckDBPyConnection:
+        if self._connection is not None:
+            raise RuntimeError("DuckDB connection is already open.")
+        self._connection = duckdb.connect(database=self.database, **self.connect_kwargs)
+        return self._connection
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        exc_tb: Any,
+    ) -> None:
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
+
+    @property
+    def is_open(self) -> bool:
+        """Return ``True`` when the managed connection is open."""
+
+        return self._connection is not None
+
+    @property
+    def connection(self) -> duckdb.DuckDBPyConnection:
+        """Access the active DuckDB connection.
+
+        Raises
+        ------
+        RuntimeError
+            If the context manager is not currently managing an open connection.
+        """
+
+        if self._connection is None:
+            raise RuntimeError("No active DuckDB connection. Use DuckCon as a context manager.")
+        return self._connection
+
+    def register_helper(
+        self,
+        name: str,
+        helper: Callable[[duckdb.DuckDBPyConnection, Any], Any],
+        *,
+        overwrite: bool = False,
+    ) -> None:
+        """Register an I/O helper callable.
+
+        Parameters
+        ----------
+        name:
+            Name used to reference the helper.
+        helper:
+            Callable that receives the active connection as its first argument.
+        overwrite:
+            Whether to overwrite an existing helper with the same name.
+        """
+
+        if not overwrite and name in self._helpers:
+            raise ValueError(f"Helper '{name}' is already registered.")
+        self._helpers[name] = helper
+
+    def apply_helper(self, name: str, *args: Any, **kwargs: Any) -> Any:
+        """Execute a registered helper with the active connection."""
+
+        if name not in self._helpers:
+            raise KeyError(f"Helper '{name}' is not registered.")
+        helper = self._helpers[name]
+        return helper(self.connection, *args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_duckcon.py
+++ b/tests/test_duckcon.py
@@ -1,0 +1,37 @@
+import duckdb
+import pytest
+
+from duckplus import DuckCon
+
+
+def test_duckcon_context_opens_and_closes_connection() -> None:
+    manager = DuckCon()
+    assert not manager.is_open
+
+    with manager as connection:
+        assert manager.is_open
+        result = connection.execute("SELECT 1").fetchone()
+        assert result == (1,)
+
+    assert not manager.is_open
+    with pytest.raises(RuntimeError):
+        _ = manager.connection
+
+
+def test_duckcon_helper_extension_point() -> None:
+    manager = DuckCon()
+
+    def echo_helper(conn: duckdb.DuckDBPyConnection, value: int) -> int:
+        return conn.execute("SELECT ?", [value]).fetchone()[0]
+
+    manager.register_helper("echo", echo_helper)
+
+    with manager:
+        assert manager.apply_helper("echo", 42) == 42
+
+    with pytest.raises(KeyError):
+        manager.apply_helper("missing")
+
+    manager.register_helper("echo", echo_helper, overwrite=True)
+    with manager:
+        assert manager.apply_helper("echo", 7) == 7


### PR DESCRIPTION
## Summary
- create the duckplus package and expose the DuckCon context manager for DuckDB connections
- add helper registration to DuckCon to enable future I/O extension points
- add tests to validate connection lifecycle management and helper extensibility

## Testing
- pytest
- mypy duckplus
- uvx --help
- pylint duckplus

------
https://chatgpt.com/codex/tasks/task_e_68eeba219fc88322b562d8a70fb191ea