### PR TITLE
Add immutable Relation wrapper

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,2 @@
 - [ ] Add a DuckCon class with a context manager that will be easy to extend for io operations
-- [ ] Add a relation class that is immutable and has the DuckCon and a duckdbpy connection under the hood with some metadata stored like columns and Duckdb types (as varchar for now)
+- [x] Add a relation class that is immutable and has the DuckCon and a duckdbpy connection under the hood with some metadata stored like columns and Duckdb types (as varchar for now)

--- a/duckplus/__init__.py
+++ b/duckplus/__init__.py
@@ -1,5 +1,6 @@
 """Top-level package for duckplus utilities."""
 
 from .duckcon import DuckCon
+from .relation import Relation
 
-__all__ = ["DuckCon"]
+__all__ = ["DuckCon", "Relation"]

--- a/duckplus/relation.py
+++ b/duckplus/relation.py
@@ -1,0 +1,64 @@
+"""Utilities for working with DuckDB relations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import duckdb
+
+from .duckcon import DuckCon
+
+
+@dataclass(frozen=True)
+class Relation:
+    """Immutable wrapper around a DuckDB relation.
+
+    The wrapper keeps track of the :class:`~duckplus.duckcon.DuckCon` that
+    produced the relation together with cached metadata describing the
+    relation's column names and DuckDB data types.
+    """
+
+    duckcon: DuckCon
+    _relation: duckdb.DuckDBPyRelation
+    _columns: tuple[str, ...] = field(init=False, repr=False)
+    _types: tuple[str, ...] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        columns = tuple(self._relation.columns)
+        # DuckDB returns custom type objects in ``relation.types`` so we cast
+        # them to their string representation for stable comparison.
+        types = tuple(str(type_) for type_ in self._relation.types)
+        object.__setattr__(self, "_columns", columns)
+        object.__setattr__(self, "_types", types)
+
+    @property
+    def columns(self) -> tuple[str, ...]:
+        """Return the column names of the wrapped relation."""
+
+        return self._columns
+
+    @property
+    def types(self) -> tuple[str, ...]:
+        """Return the DuckDB data types associated with the relation."""
+
+        return self._types
+
+    @property
+    def relation(self) -> duckdb.DuckDBPyRelation:
+        """Expose the underlying DuckDB relation."""
+
+        return self._relation
+
+    @classmethod
+    def from_relation(cls, duckcon: DuckCon, relation: duckdb.DuckDBPyRelation) -> "Relation":
+        """Create a :class:`Relation` from an existing DuckDB relation."""
+
+        return cls(duckcon=duckcon, _relation=relation)
+
+    @classmethod
+    def from_sql(cls, duckcon: DuckCon, query: str) -> "Relation":
+        """Create a relation from a SQL query executed on a managed connection."""
+
+        connection = duckcon.connection
+        relation = connection.sql(query)
+        return cls.from_relation(duckcon, relation)

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -1,0 +1,51 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from duckplus import DuckCon, Relation
+
+
+def _make_relation(manager: DuckCon, query: str) -> Relation:
+    with manager as connection:
+        duck_relation = connection.sql(query)
+        return Relation.from_relation(manager, duck_relation)
+
+
+def test_relation_is_immutable() -> None:
+    manager = DuckCon()
+    relation = _make_relation(manager, "SELECT 1 AS value")
+
+    with pytest.raises(FrozenInstanceError):
+        relation.columns = ("other",)
+
+    with pytest.raises(FrozenInstanceError):
+        relation.types = ("INTEGER",)
+
+
+def test_relation_metadata_populated() -> None:
+    manager = DuckCon()
+
+    relation = _make_relation(
+        manager,
+        "SELECT 1::INTEGER AS value, 'text'::VARCHAR AS label",
+    )
+
+    assert relation.columns == ("value", "label")
+    assert relation.types == ("INTEGER", "VARCHAR")
+
+
+def test_relation_from_sql_uses_active_connection() -> None:
+    manager = DuckCon()
+
+    with manager:
+        relation = Relation.from_sql(manager, "SELECT 42 AS answer")
+
+    assert relation.columns == ("answer",)
+    assert relation.types == ("INTEGER",)
+
+
+def test_relation_from_sql_requires_active_connection() -> None:
+    manager = DuckCon()
+
+    with pytest.raises(RuntimeError):
+        Relation.from_sql(manager, "SELECT 1")


### PR DESCRIPTION
## Summary
- add an immutable Relation dataclass that caches DuckDB column metadata
- expose Relation from the duckplus package and mark the TODO entry as completed
- cover the new functionality with unit tests for immutability and metadata population

## Testing
- mypy duckplus
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eebb7803d48322a141c5a2e12b8574