### PR TITLE
Refine roadmap and stewardship guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,14 @@
 # Always Do these steps before commit
-
 1. Make sure docs are up to date
 2. run mypy and uvx and pylint
 3. run tests
 4. make sure all tests pass
 5. add any tests that are needed
 6. make sure they past
-
 # Users will develop the api surface requests in TODO.md
-
 1. harmonously work to implement the new feature
 2. Ensure it has no unexpected behaviour and does not regress
 3. hide it in TODO.md
+
+## TODO Stewardship Directive
+- Keep the preflight discovery questions in `TODO.md` current. After checking off any TODO item, review the repository for new learnings and update the question list so it stays relevant and high-signal for upcoming work.


### PR DESCRIPTION
## Summary
- Restructured TODO.md into a roadmap with preflight discovery questions and detailed, bite-sized task groups.
- Added an AGENTS.md directive to keep the preflight question list fresh after each TODO completion.

## Testing
- `mypy .`
- `uvx --help`
- `pylint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68eec04421388322a39adc374649e59f