### PR TITLE
Add rename helpers for Relation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -25,8 +25,8 @@ Answer these before starting any TODO item to confirm the work is understood and
   - [x] Implement `Relation.transform(**replacements)` that issues a `SELECT * REPLACE` statement and validates referenced columns.
   - [x] Provide ergonomic overloads for simple casts, e.g. `relation.transform(column="column::INTEGER")`.
 - [ ] Rename helpers
-  - [ ] Implement `Relation.rename(**renames)` backed by `SELECT * RENAME` and ensure conflicting names raise clear errors.
-  - [ ] Add `rename_if_exists` soft variant that skips missing columns with warnings/logging.
+  - [x] Implement `Relation.rename(**renames)` backed by `SELECT * RENAME` and ensure conflicting names raise clear errors.
+  - [x] Add `rename_if_exists` soft variant that skips missing columns with warnings/logging.
 - [ ] Column addition helpers
   - [ ] Implement `Relation.add(**expressions)` using `SELECT *, <expr> AS <alias>`.
   - [ ] Support dependent expressions (new columns referencing existing ones) with validation.

--- a/tests/test_relation.py
+++ b/tests/test_relation.py
@@ -134,3 +134,90 @@ def test_transform_requires_open_connection() -> None:
 
     with pytest.raises(RuntimeError):
         relation.transform(value="value + 1")
+
+
+def test_rename_updates_column_names() -> None:
+    manager = DuckCon()
+    with manager as connection:
+        relation = Relation.from_relation(
+            manager,
+            connection.sql("SELECT 1::INTEGER AS value, 2::INTEGER AS other"),
+        )
+
+        renamed = relation.rename(value="first", other="second")
+
+        assert renamed.columns == ("first", "second")
+        assert renamed.types == ("INTEGER", "INTEGER")
+        assert renamed.relation.fetchall() == [(1, 2)]
+
+
+def test_rename_rejects_unknown_columns() -> None:
+    manager = DuckCon()
+    with manager as connection:
+        relation = Relation.from_relation(
+            manager,
+            connection.sql("SELECT 1::INTEGER AS value"),
+        )
+
+        with pytest.raises(KeyError):
+            relation.rename(other="value")
+
+
+def test_rename_rejects_duplicate_targets() -> None:
+    manager = DuckCon()
+    with manager as connection:
+        relation = Relation.from_relation(
+            manager,
+            connection.sql("SELECT 1::INTEGER AS value, 2::INTEGER AS other"),
+        )
+
+        with pytest.raises(ValueError, match="duplicate column names"):
+            relation.rename(value="other")
+
+
+def test_rename_rejects_invalid_targets() -> None:
+    manager = DuckCon()
+    with manager as connection:
+        relation = Relation.from_relation(
+            manager,
+            connection.sql("SELECT 1::INTEGER AS value"),
+        )
+
+        with pytest.raises(ValueError):
+            relation.rename(value="")
+
+
+def test_rename_requires_open_connection() -> None:
+    manager = DuckCon()
+    relation = _make_relation(
+        manager,
+        "SELECT 1::INTEGER AS value, 2::INTEGER AS other",
+    )
+
+    with pytest.raises(RuntimeError):
+        relation.rename(value="first")
+
+
+def test_rename_if_exists_skips_missing_columns() -> None:
+    manager = DuckCon()
+    with manager as connection:
+        relation = Relation.from_relation(
+            manager,
+            connection.sql("SELECT 1::INTEGER AS value"),
+        )
+
+        with pytest.warns(UserWarning, match="skipped"):
+            renamed = relation.rename_if_exists(value="first", other="second")
+
+        assert renamed.columns == ("first",)
+        assert renamed.relation.fetchall() == [(1,)]
+
+
+def test_rename_if_exists_returns_original_when_nothing_to_rename() -> None:
+    manager = DuckCon()
+    relation = _make_relation(manager, "SELECT 1::INTEGER AS value")
+
+    with pytest.warns(UserWarning):
+        result = relation.rename_if_exists(other="second")
+
+    assert result is relation


### PR DESCRIPTION
## Summary
- add `Relation.rename` and `Relation.rename_if_exists` helpers with validation, duplicate detection, and warning support
- factor supporting utilities inside `Relation` to reuse rename validation logic
- mark the rename helper tasks complete in the roadmap and extend relation tests to cover the new behaviours

## Testing
- mypy duckplus
- uvx --version
- pylint duckplus
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eec6f566f08322865d22ee231e2fb1