### PR TITLE
Add keep/drop helpers with case-insensitive column handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,11 +31,11 @@ Answer these before starting any TODO item to confirm the work is understood and
   - [x] Implement `Relation.add(**expressions)` using `SELECT *, <expr> AS <alias>`.
   - [ ] Support dependent expressions (new columns referencing existing ones) with validation (blocked by typed expression API; see notes below).
 - [ ] Column subset helpers
-  - [ ] Implement `Relation.keep(*columns)` to project only requested columns, raising on unknown names by default.
-  - [ ] Provide `keep_if_exists` variant that tolerates absent columns.
+  - [x] Implement `Relation.keep(*columns)` to project only requested columns, raising on unknown names by default.
+  - [x] Provide `keep_if_exists` variant that tolerates absent columns.
 - [ ] Column drop helpers
-  - [ ] Implement `Relation.drop(*columns)` using `SELECT * EXCLUDE` semantics with strict validation.
-  - [ ] Provide `drop_if_exists` soft variant mirroring `keep_if_exists` behaviour.
+  - [x] Implement `Relation.drop(*columns)` using `SELECT * EXCLUDE` semantics with strict validation.
+  - [x] Provide `drop_if_exists` soft variant mirroring `keep_if_exists` behaviour.
 
 ## Typed Expression API
 - [ ] Design fluent `ducktype` factory with concrete types (e.g. `Numeric`, `Varchar`, `Blob`).


### PR DESCRIPTION
## Summary
- add keep/keep_if_exists and drop/drop_if_exists helpers that operate with case-insensitive column selection
- make existing column-manipulation utilities resolve columns case-insensitively and guard against ambiguous matches
- expand the relation test suite to cover the new helpers and case-insensitive behaviours

## Testing
- mypy duckplus
- uvx
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68eecdd35b788322acea530afc99e29b