### PR TITLE
Add Pi demo for typed expressions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,11 +38,11 @@ Answer these before starting any TODO item to confirm the work is understood and
   - [x] Provide `drop_if_exists` soft variant mirroring `keep_if_exists` behaviour.
 
 ## Typed Expression API
-- [ ] Design fluent `ducktype` factory with concrete types (e.g. `Numeric`, `Varchar`, `Blob`).
-  - [ ] Ensure concrete types remain composable so future composed/aggregated types (structs, lists) can wrap them without loss of metadata.
-- [ ] Surface aggregation helpers, e.g. `ducktype.Numeric.Aggregate.sum("sales") -> "sum(sales)"`.
-- [ ] Enable expression comparisons (`ducktype.Varchar("customer") == "prime"`) and joins between differently named columns.
-- [ ] Support aliasing and renaming via methods like `.alias("my_customer")` with dict/str serialization.
+- [x] Design fluent `ducktype` factory with concrete types (e.g. `Numeric`, `Varchar`, `Blob`).
+  - [x] Ensure concrete types remain composable so future composed/aggregated types (structs, lists) can wrap them without loss of metadata.
+- [x] Surface aggregation helpers, e.g. `ducktype.Numeric.Aggregate.sum("sales") -> "sum(sales)"`.
+- [x] Enable expression comparisons (`ducktype.Varchar("customer") == "prime"`) and joins between differently named columns.
+- [x] Support aliasing and renaming via methods like `.alias("my_customer")` with dict/str serialization.
 - [ ] Add window function construction helpers on typed expressions.
 
 ### Notes for "Typed Expression API"

--- a/docs/pi_demo.md
+++ b/docs/pi_demo.md
@@ -1,0 +1,36 @@
+# Raspberry Pi Typed Expression Demo
+
+The `duckplus.examples.pi_demo` module provides a hands-on walkthrough for the
+typed expression API using a circle-math scenario built around π.  The helper
+functions generate projection and aggregation SQL while preserving metadata such
+as column dependencies and type annotations.
+
+## Running the Demo Queries
+
+The module is packaged so you can execute it directly::
+
+    python -m duckplus.examples.pi_demo
+
+If DuckDB is not installed you will receive a friendly error message explaining
+how to add it.  Once DuckDB is available, the script creates a small `circles`
+table and executes two queries built from typed expressions:
+
+* A projection that surfaces the raw radius alongside calculated area and
+  circumference columns.
+* An aggregation that totals area and circumference across the dataset.
+
+## Type Checker Feedback
+
+We include ``reveal_type`` probes guarded by ``TYPE_CHECKING`` inside the module
+so that ``mypy`` (or another static type checker) can confirm the expression
+shapes.  Running::
+
+    mypy -p duckplus.examples.pi_demo
+
+produces output similar to::
+
+    note: Revealed type is "duckplus.typed.expression.NumericExpression"
+    note: Revealed type is "duckplus.typed.expression.NumericExpression"
+
+This gives immediate assurance that downstream helpers receive strongly-typed
+expressions with preserved dependencies.

--- a/duckplus/__init__.py
+++ b/duckplus/__init__.py
@@ -1,6 +1,28 @@
 """Top-level package for duckplus utilities."""
 
-from .duckcon import DuckCon
-from .relation import Relation
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 __all__ = ["DuckCon", "Relation"]
+
+try:  # pragma: no branch - small module guard
+    from .duckcon import DuckCon
+    from .relation import Relation
+except ModuleNotFoundError as exc:  # pragma: no cover - depends on duckdb
+    if TYPE_CHECKING:  # pragma: no cover - import-time hinting only
+        from .duckcon import DuckCon  # type: ignore # noqa: F401
+        from .relation import Relation  # type: ignore # noqa: F401
+    else:
+        _IMPORT_ERROR = exc
+
+        def __getattr__(name: str):
+            if name in {"DuckCon", "Relation"}:
+                message = (
+                    "DuckDB is required to use duckplus.DuckCon or duckplus.Relation. "
+                    "Install it with 'pip install duckdb' to unlock database helpers."
+                )
+                raise ModuleNotFoundError(message) from _IMPORT_ERROR
+            raise AttributeError(name) from None
+
+        DuckCon = Relation = None  # type: ignore[assignment]  # pylint: disable=invalid-name

--- a/duckplus/duckcon.py
+++ b/duckplus/duckcon.py
@@ -1,11 +1,13 @@
 """Context manager utilities for DuckDB connections."""
 
+# pylint: disable=import-error
+
 from __future__ import annotations
 
 from collections.abc import Callable
 from typing import Any, Optional
 
-import duckdb
+import duckdb  # type: ignore[import-not-found]
 
 
 class DuckCon:

--- a/duckplus/examples/__init__.py
+++ b/duckplus/examples/__init__.py
@@ -1,0 +1,3 @@
+"""Example scripts demonstrating DuckPlus capabilities."""
+
+__all__ = ["pi_demo"]

--- a/duckplus/examples/pi_demo.py
+++ b/duckplus/examples/pi_demo.py
@@ -1,0 +1,145 @@
+"""Circle-math demo showcasing typed expressions with Pi-friendly calculations.
+
+This module highlights how DuckPlus typed expressions can be composed to build
+DuckDB SQL while retaining strong typing information.  It is designed to run on
+resource-constrained hosts (like a Raspberry Pi) without needing DuckDB at
+import time.  If DuckDB is available, :func:`run_duckdb_demo` executes the SQL
+that the expressions render so you can inspect real results.
+
+To inspect the static typing feedback these helpers provide, run::
+
+    mypy -p duckplus.examples.pi_demo
+
+The module includes ``reveal_type`` probes guarded by ``TYPE_CHECKING`` so the
+type checker will surface the expression types when you run the command above.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence, TYPE_CHECKING
+
+from duckplus.typed import AliasedExpression, NumericExpression, TypedExpression, ducktype
+
+if TYPE_CHECKING:  # pragma: no cover - executed only during type checking
+    from typing import reveal_type
+
+    _radius_probe = ducktype.Numeric("radius")
+    reveal_type(_radius_probe)
+    _radius_sum = ducktype.Numeric.Aggregate.sum(_radius_probe)
+    reveal_type(_radius_sum)
+
+
+@dataclass(frozen=True)
+class CircleExpressions:
+    """Reusable expressions describing circle metrics."""
+
+    radius: NumericExpression
+    area: NumericExpression
+    circumference: NumericExpression
+
+
+def build_circle_expressions(radius_column: str = "radius") -> CircleExpressions:
+    """Construct numeric expressions for circle area and circumference.
+
+    Parameters
+    ----------
+    radius_column:
+        Name of the column supplying circle radii.
+    """
+
+    radius = ducktype.Numeric(radius_column)
+    pi_literal = ducktype.Numeric.raw(
+        "3.141592653589793::DOUBLE", type_annotation="DOUBLE"
+    )
+    area = pi_literal * radius * radius
+    circumference = pi_literal * radius * ducktype.Numeric.literal(2)
+    return CircleExpressions(radius=radius, area=area, circumference=circumference)
+
+
+def project_circle_metrics(radius_column: str = "radius") -> Sequence[AliasedExpression]:
+    """Return aliased projections for radius, area, and circumference."""
+
+    expressions = build_circle_expressions(radius_column)
+    return (
+        expressions.radius.alias("radius"),
+        expressions.area.alias("area"),
+        expressions.circumference.alias("circumference"),
+    )
+
+
+def summarise_circle_metrics(radius_column: str = "radius") -> Sequence[AliasedExpression]:
+    """Produce aggregations that total area and circumference."""
+
+    expressions = build_circle_expressions(radius_column)
+    return (
+        ducktype.Numeric.Aggregate.sum(expressions.area).alias("total_area"),
+        ducktype.Numeric.Aggregate.sum(expressions.circumference).alias("total_circumference"),
+    )
+
+
+def render_select_sql(
+    select_list: Iterable[TypedExpression],
+    relation_sql: str,
+) -> str:
+    """Render a SELECT statement using the provided expressions."""
+
+    projections = ", ".join(expression.render() for expression in select_list)
+    return f"SELECT {projections} FROM {relation_sql}"
+
+
+def build_demo_queries(radius_column: str = "radius") -> dict[str, str]:
+    """Generate demo SQL queries illustrating projection and aggregation."""
+
+    projection = render_select_sql(project_circle_metrics(radius_column), "circles")
+    summary = render_select_sql(summarise_circle_metrics(radius_column), "circles")
+    return {"projection": projection, "summary": summary}
+
+
+def run_duckdb_demo() -> Sequence[tuple[str, Sequence[tuple[object, ...]]]]:
+    """Execute the demo SQL against DuckDB if the package is installed."""
+
+    queries = build_demo_queries()
+    try:
+        import duckdb  # type: ignore[import-not-found]  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError as exc:  # pragma: no cover - depends on environment
+        message = (
+            "DuckDB is not installed. Install it with 'pip install duckdb' to run the "
+            "demo queries on your Raspberry Pi."
+        )
+        raise RuntimeError(message) from exc
+
+    connection = duckdb.connect()
+    try:
+        connection.execute(
+            "CREATE TABLE circles AS SELECT * FROM (VALUES (1.5), (2.0), (3.25)) AS t(radius)"
+        )
+        results: list[tuple[str, Sequence[tuple[object, ...]]]] = []
+        for name, sql in queries.items():
+            results.append((name, connection.execute(sql).fetchall()))
+        return results
+    finally:
+        connection.close()
+
+
+def main() -> None:
+    """Entry point used when running the module as a script."""
+
+    queries = build_demo_queries()
+    try:
+        results = run_duckdb_demo()
+    except RuntimeError as exc:
+        print(exc)
+        print("\nGenerated SQL:")
+        for name, sql in queries.items():
+            print(f"- {name}: {sql}")
+        return
+
+    for name, rows in results:
+        print(f"Query: {name}")
+        for row in rows:
+            print("  ", row)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation utility
+    main()

--- a/duckplus/typed/__init__.py
+++ b/duckplus/typed/__init__.py
@@ -1,0 +1,26 @@
+"""Typed expression primitives for DuckPlus."""
+
+from .expression import (
+    AliasedExpression,
+    BlobExpression,
+    BooleanExpression,
+    GenericExpression,
+    NumericExpression,
+    TypedExpression,
+    VarcharExpression,
+    ducktype,
+)
+from .functions import DuckDBCatalogUnavailableError, DuckDBFunctionNamespace
+
+__all__ = [
+    "AliasedExpression",
+    "BlobExpression",
+    "BooleanExpression",
+    "GenericExpression",
+    "NumericExpression",
+    "TypedExpression",
+    "VarcharExpression",
+    "ducktype",
+    "DuckDBCatalogUnavailableError",
+    "DuckDBFunctionNamespace",
+]

--- a/duckplus/typed/expression.py
+++ b/duckplus/typed/expression.py
@@ -1,0 +1,517 @@
+"""Typed expression primitives used for building DuckDB SQL."""
+
+# pylint: disable=too-few-public-methods,missing-function-docstring,missing-class-docstring,invalid-name,import-outside-toplevel
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import NotImplementedType
+from typing import TYPE_CHECKING, Callable, Iterable, TypeVar, Union
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type checking
+    from .functions import DuckDBFunctionNamespace
+
+
+def _quote_identifier(identifier: str) -> str:
+    escaped = identifier.replace("\"", "\"\"")
+    return f'"{escaped}"'
+
+
+def _quote_string(value: str) -> str:
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+ExpressionT = TypeVar("ExpressionT", bound="TypedExpression")
+ComparisonResult = Union["BooleanExpression", NotImplementedType]
+
+
+class TypedExpression:
+    """Representation of a typed SQL expression."""
+
+    __slots__ = ("_sql", "type_annotation", "_dependencies")
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        type_annotation: str,
+        dependencies: Iterable[str] = (),
+    ) -> None:
+        self._sql = sql
+        self.type_annotation = type_annotation
+        self._dependencies = frozenset(dependencies)
+
+    def render(self) -> str:
+        """Return a SQL representation of the expression."""
+
+        return self._sql
+
+    def __str__(self) -> str:  # pragma: no cover - delegation to ``render``
+        return self.render()
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"{self.__class__.__name__}({self.render()!r})"
+
+    @property
+    def dependencies(self) -> frozenset[str]:
+        """Columns referenced by the expression."""
+
+        return self._dependencies
+
+    def alias(self, alias: str) -> "AliasedExpression":
+        """Return an aliased version of the expression."""
+
+        return AliasedExpression(base=self, alias=alias)
+
+    # Comparisons -----------------------------------------------------
+    def _comparison(self: ExpressionT, operator: str, other: object) -> "BooleanExpression":
+        operand = self._coerce_operand(other)
+        sql = f"({self.render()} {operator} {operand.render()})"
+        dependencies = self.dependencies.union(operand.dependencies)
+        return BooleanExpression(sql, dependencies=dependencies)
+
+    def _coerce_operand(self: ExpressionT, other: object) -> ExpressionT:
+        raise NotImplementedError
+
+    def __eq__(self, other: object) -> ComparisonResult:  # type: ignore[override]
+        if isinstance(other, (TypedExpression, str, int, float, Decimal, bool, bytes)):
+            return self._comparison("=", other)
+        return NotImplemented
+
+    def __ne__(self, other: object) -> ComparisonResult:  # type: ignore[override]
+        if isinstance(other, (TypedExpression, str, int, float, Decimal, bool, bytes)):
+            return self._comparison("!=", other)
+        return NotImplemented
+
+
+class AliasedExpression(TypedExpression):
+    """Adapter adding an alias to an expression during rendering."""
+
+    __slots__ = ("base", "alias_name")
+
+    def __init__(self, *, base: TypedExpression, alias: str) -> None:
+        self.base = base
+        self.alias_name = alias
+        super().__init__(
+            base.render(),
+            type_annotation=base.type_annotation,
+            dependencies=base.dependencies,
+        )
+
+    def render(self) -> str:
+        return f"{self.base.render()} AS {_quote_identifier(self.alias_name)}"
+
+    def _coerce_operand(self, other: object) -> TypedExpression:  # type: ignore[override]
+        return self.base._coerce_operand(other)  # pylint: disable=protected-access
+
+
+class BooleanExpression(TypedExpression):
+    """Boolean expressions support logical composition."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "BOOLEAN",
+    ) -> None:
+        super().__init__(sql, type_annotation=type_annotation, dependencies=dependencies)
+
+    def __and__(self, other: object) -> "BooleanExpression":
+        operand = self._coerce_operand(other)
+        sql = f"({self.render()} AND {operand.render()})"
+        dependencies = self.dependencies.union(operand.dependencies)
+        return BooleanExpression(sql, dependencies=dependencies)
+
+    def __or__(self, other: object) -> "BooleanExpression":
+        operand = self._coerce_operand(other)
+        sql = f"({self.render()} OR {operand.render()})"
+        dependencies = self.dependencies.union(operand.dependencies)
+        return BooleanExpression(sql, dependencies=dependencies)
+
+    def __invert__(self) -> "BooleanExpression":
+        return BooleanExpression(f"(NOT {self.render()})", dependencies=self.dependencies)
+
+    def _coerce_operand(self, other: object) -> "BooleanExpression":
+        if isinstance(other, BooleanExpression):
+            return other
+        if isinstance(other, bool):
+            sql = "TRUE" if other else "FALSE"
+            return BooleanExpression(sql)
+        msg = "Boolean expressions only accept other boolean expressions or bool literals"
+        raise TypeError(msg)
+
+
+NumericOperand = int | float | Decimal
+
+
+class NumericExpression(TypedExpression):
+    """Numeric expressions provide arithmetic helpers."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "NUMERIC",
+    ) -> None:
+        super().__init__(sql, type_annotation=type_annotation, dependencies=dependencies)
+
+    @classmethod
+    def column(cls, name: str) -> "NumericExpression":
+        return cls(_quote_identifier(name), dependencies=(name,))
+
+    @classmethod
+    def literal(
+        cls,
+        value: NumericOperand,
+        *,
+        type_annotation: str = "NUMERIC",
+    ) -> "NumericExpression":
+        return cls(_format_numeric(value), type_annotation=type_annotation)
+
+    @classmethod
+    def raw(
+        cls,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "NUMERIC",
+    ) -> "NumericExpression":
+        return cls(sql, dependencies=dependencies, type_annotation=type_annotation)
+
+    def _coerce_operand(self, other: object) -> "NumericExpression":
+        if isinstance(other, NumericExpression):
+            return other
+        if isinstance(other, (int, float, Decimal)):
+            return NumericExpression.literal(other)
+        msg = "Numeric expressions only accept numeric operands"
+        raise TypeError(msg)
+
+    def _binary(self, operator: str, other: object) -> "NumericExpression":
+        operand = self._coerce_operand(other)
+        sql = f"({self.render()} {operator} {operand.render()})"
+        dependencies = self.dependencies.union(operand.dependencies)
+        return NumericExpression(sql, dependencies=dependencies)
+
+    def __add__(self, other: object) -> "NumericExpression":
+        return self._binary("+", other)
+
+    def __sub__(self, other: object) -> "NumericExpression":
+        return self._binary("-", other)
+
+    def __mul__(self, other: object) -> "NumericExpression":
+        return self._binary("*", other)
+
+    def __truediv__(self, other: object) -> "NumericExpression":
+        return self._binary("/", other)
+
+    def __mod__(self, other: object) -> "NumericExpression":
+        return self._binary("%", other)
+
+    def __pow__(self, other: object) -> "NumericExpression":
+        return self._binary("^", other)
+
+class VarcharExpression(TypedExpression):
+    """Varchar expressions enable string comparisons."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "VARCHAR",
+    ) -> None:
+        super().__init__(sql, type_annotation=type_annotation, dependencies=dependencies)
+
+    @classmethod
+    def column(cls, name: str) -> "VarcharExpression":
+        return cls(_quote_identifier(name), dependencies=(name,))
+
+    @classmethod
+    def literal(
+        cls,
+        value: str,
+        *,
+        type_annotation: str = "VARCHAR",
+    ) -> "VarcharExpression":
+        return cls(_quote_string(value), type_annotation=type_annotation)
+
+    @classmethod
+    def raw(
+        cls,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "VARCHAR",
+    ) -> "VarcharExpression":
+        return cls(sql, dependencies=dependencies, type_annotation=type_annotation)
+
+    def _coerce_operand(self, other: object) -> "VarcharExpression":
+        if isinstance(other, VarcharExpression):
+            return other
+        if isinstance(other, str):
+            return VarcharExpression.literal(other)
+        msg = "Varchar expressions only accept string operands"
+        raise TypeError(msg)
+
+
+class BlobExpression(TypedExpression):
+    """Binary expressions represent DuckDB BLOB values."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "BLOB",
+    ) -> None:
+        super().__init__(sql, type_annotation=type_annotation, dependencies=dependencies)
+
+    @classmethod
+    def column(cls, name: str) -> "BlobExpression":
+        return cls(_quote_identifier(name), dependencies=(name,))
+
+    @classmethod
+    def literal(
+        cls,
+        value: bytes,
+        *,
+        type_annotation: str = "BLOB",
+    ) -> "BlobExpression":
+        hex_literal = value.hex()
+        return cls(f"BLOB '\\x{hex_literal}'", type_annotation=type_annotation)
+
+    @classmethod
+    def raw(
+        cls,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "BLOB",
+    ) -> "BlobExpression":
+        return cls(sql, dependencies=dependencies, type_annotation=type_annotation)
+
+    def _coerce_operand(self, other: object) -> "BlobExpression":
+        if isinstance(other, BlobExpression):
+            return other
+        if isinstance(other, bytes):
+            return BlobExpression.literal(other)
+        msg = "Blob expressions only accept bytes operands"
+        raise TypeError(msg)
+
+
+class GenericExpression(TypedExpression):
+    """Representation of a DuckDB expression with unknown concrete type."""
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        sql: str,
+        *,
+        type_annotation: str = "UNKNOWN",
+        dependencies: Iterable[str] = (),
+    ) -> None:
+        super().__init__(sql, type_annotation=type_annotation, dependencies=dependencies)
+
+    def _coerce_operand(self, other: object) -> "GenericExpression":
+        if isinstance(other, TypedExpression):
+            return GenericExpression(
+                other.render(),
+                type_annotation=other.type_annotation,
+                dependencies=other.dependencies,
+            )
+        msg = "Generic expressions only accept other SQL expressions"
+        raise TypeError(msg)
+
+
+class _NumericAggregateFactory:
+    def __init__(
+        self,
+        factory: "NumericFactory",
+        *,
+        function_namespace: "DuckDBFunctionNamespace | None" = None,
+    ) -> None:
+        self._factory = factory
+        self._function_namespace = function_namespace
+
+    def _from_function_namespace(
+        self, name: str
+    ) -> Callable[..., NumericExpression] | None:
+        if self._function_namespace is None:
+            return None
+        try:
+            accessor = self._function_namespace.Aggregate.Numeric
+        except RuntimeError:
+            return None
+        if hasattr(accessor, name):
+            function = getattr(accessor, name)
+            return function  # type: ignore[return-value]
+        try:
+            function = accessor[name]
+        except KeyError:
+            return None
+        return function  # type: ignore[return-value]
+
+    def __getattr__(self, name: str):
+        function = self._from_function_namespace(name)
+        if function is None:
+            msg = f"Aggregate function '{name}' is not available"
+            raise AttributeError(msg) from None
+
+        def wrapper(*operands: object) -> NumericExpression:
+            return function(*operands)
+
+        return wrapper
+
+    def sum(self, operand: object) -> NumericExpression:
+        function = self._from_function_namespace("sum")
+        if function is not None:
+            return function(operand)
+        expression = self._factory.coerce(operand)
+        sql = f"sum({expression.render()})"
+        return NumericExpression(sql, dependencies=expression.dependencies)
+
+
+class NumericFactory:
+    """Factory for creating numeric expressions."""
+
+    def __init__(
+        self,
+        function_namespace: "DuckDBFunctionNamespace | None" = None,
+    ) -> None:
+        self._function_namespace = function_namespace
+
+    def __call__(self, column: str) -> NumericExpression:
+        return NumericExpression.column(column)
+
+    def literal(self, value: NumericOperand) -> NumericExpression:
+        return NumericExpression.literal(value)
+
+    def raw(
+        self,
+        sql: str,
+        *,
+        dependencies: Iterable[str] = (),
+        type_annotation: str = "NUMERIC",
+    ) -> NumericExpression:
+        return NumericExpression.raw(
+            sql,
+            dependencies=dependencies,
+            type_annotation=type_annotation,
+        )
+
+    def coerce(self, operand: object) -> NumericExpression:
+        if isinstance(operand, NumericExpression):
+            return operand
+        if isinstance(operand, str):
+            return self(operand)
+        if isinstance(operand, (int, float, Decimal)):
+            return self.literal(operand)
+        msg = "Unsupported operand for numeric expression"
+        raise TypeError(msg)
+
+    @property
+    def Aggregate(self) -> _NumericAggregateFactory:
+        return _NumericAggregateFactory(
+            self,
+            function_namespace=self._function_namespace,
+        )
+
+
+class VarcharFactory:
+    """Factory for creating varchar expressions."""
+
+    def __call__(self, column: str) -> VarcharExpression:
+        return VarcharExpression.column(column)
+
+    def literal(self, value: str) -> VarcharExpression:
+        return VarcharExpression.literal(value)
+
+    def raw(self, sql: str, *, dependencies: Iterable[str] = ()) -> VarcharExpression:
+        return VarcharExpression.raw(sql, dependencies=dependencies)
+
+    def coerce(self, operand: object) -> VarcharExpression:
+        if isinstance(operand, VarcharExpression):
+            return operand
+        if isinstance(operand, str):
+            return self.literal(operand)
+        msg = "Unsupported operand for varchar expression"
+        raise TypeError(msg)
+
+
+class BooleanFactory:
+    """Factory for creating boolean expressions."""
+
+    def __call__(self, column: str) -> BooleanExpression:
+        return BooleanExpression(_quote_identifier(column), dependencies=(column,))
+
+    def literal(self, value: bool) -> BooleanExpression:
+        return BooleanExpression("TRUE" if value else "FALSE")
+
+    def raw(self, sql: str, *, dependencies: Iterable[str] = ()) -> BooleanExpression:
+        return BooleanExpression(sql, dependencies=dependencies)
+
+    def coerce(self, operand: object) -> BooleanExpression:
+        if isinstance(operand, BooleanExpression):
+            return operand
+        if isinstance(operand, bool):
+            return self.literal(operand)
+        msg = "Boolean operands must be expression or bool"
+        raise TypeError(msg)
+
+
+class BlobFactory:
+    """Factory for creating blob expressions."""
+
+    def __call__(self, column: str) -> BlobExpression:
+        return BlobExpression.column(column)
+
+    def literal(self, value: bytes) -> BlobExpression:
+        return BlobExpression.literal(value)
+
+    def raw(self, sql: str, *, dependencies: Iterable[str] = ()) -> BlobExpression:
+        return BlobExpression.raw(sql, dependencies=dependencies)
+
+    def coerce(self, operand: object) -> BlobExpression:
+        if isinstance(operand, BlobExpression):
+            return operand
+        if isinstance(operand, bytes):
+            return self.literal(operand)
+        msg = "Unsupported operand for blob expression"
+        raise TypeError(msg)
+
+
+class DuckTypeNamespace:
+    """Container exposing typed expression factories and DuckDB functions."""
+
+    def __init__(self) -> None:
+        from .functions import DuckDBFunctionNamespace  # Local import to avoid cycle
+
+        functions = DuckDBFunctionNamespace()
+        self.Functions = functions
+        self.Numeric = NumericFactory(functions)
+        self.Varchar = VarcharFactory()
+        self.Boolean = BooleanFactory()
+        self.Blob = BlobFactory()
+
+
+def _format_numeric(value: NumericOperand) -> str:
+    if isinstance(value, bool):  # bool is subclass of int, exclude early
+        raise TypeError("Boolean values are not valid numeric literals")
+    if isinstance(value, Decimal):
+        return format(value, "f")
+    return repr(value)
+
+
+ducktype = DuckTypeNamespace()

--- a/duckplus/typed/functions.py
+++ b/duckplus/typed/functions.py
@@ -1,0 +1,346 @@
+"""DuckDB function catalog to power typed expression helpers."""
+
+# pylint: disable=missing-function-docstring,too-few-public-methods,invalid-name,import-outside-toplevel,method-cache-max-size-none
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from decimal import Decimal
+from typing import Callable, Iterable, Mapping, Sequence
+
+from .expression import (
+    BlobExpression,
+    BooleanExpression,
+    GenericExpression,
+    NumericExpression,
+    TypedExpression,
+    VarcharExpression,
+)
+from .expression import _quote_identifier  # pylint: disable=protected-access
+
+
+class DuckDBCatalogUnavailableError(RuntimeError):
+    """Raised when DuckDB function metadata cannot be loaded."""
+
+
+@dataclass(frozen=True)
+class DuckDBFunctionDefinition:
+    """Captured metadata describing a DuckDB function overload."""
+
+    schema_name: str
+    function_name: str
+    function_type: str
+    return_type: str | None
+    parameter_types: tuple[str, ...]
+    varargs: str | None
+
+    def matches_arity(self, argument_count: int) -> bool:
+        required = len(self.parameter_types)
+        if self.varargs is None:
+            return argument_count == required
+        return argument_count >= required
+
+
+class DuckDBFunctionCatalog:
+    """Index of DuckDB functions grouped by type and return category."""
+
+    _SCHEMA_PRIORITY = {"main": 0, "duckdb": 1, "pg_catalog": 2}
+
+    def __init__(self, definitions: Sequence[DuckDBFunctionDefinition]):
+        index: dict[str, dict[str, dict[str, list[DuckDBFunctionDefinition]]]] = {}
+        for definition in definitions:
+            category = _categorise_return_type(definition.return_type)
+            type_bucket = index.setdefault(definition.function_type, {})
+            category_bucket = type_bucket.setdefault(category, {})
+            overloads = category_bucket.setdefault(definition.function_name, [])
+            overloads.append(definition)
+
+        for type_bucket in index.values():
+            for category_bucket in type_bucket.values():
+                for variants in category_bucket.values():
+                    variants.sort(key=self._definition_sort_key)
+
+        self._index = index
+
+    @staticmethod
+    def _definition_sort_key(definition: DuckDBFunctionDefinition) -> tuple[int, int]:
+        schema_priority = DuckDBFunctionCatalog._SCHEMA_PRIORITY.get(
+            definition.schema_name, 10
+        )
+        arity = len(definition.parameter_types)
+        return (schema_priority, arity)
+
+    @classmethod
+    def load(cls) -> DuckDBFunctionCatalog:
+        try:
+            import duckdb  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - depends on env
+            raise DuckDBCatalogUnavailableError(
+                "The 'duckdb' package is required to enumerate DuckDB functions"
+            ) from exc
+
+        connection = duckdb.connect()
+        try:
+            query = connection.execute(
+                """
+                SELECT schema_name, function_name, function_type, return_type,
+                       parameter_types, varargs
+                  FROM duckdb_functions()
+                 WHERE function_type IN ('scalar', 'aggregate', 'window')
+                """
+            )
+            rows = query.fetchall()
+        finally:
+            connection.close()
+
+        definitions = [
+            DuckDBFunctionDefinition(
+                schema_name=row[0],
+                function_name=row[1],
+                function_type=row[2],
+                return_type=row[3],
+                parameter_types=tuple(row[4] or ()),
+                varargs=row[5],
+            )
+            for row in rows
+        ]
+        return cls(definitions)
+
+    def functions_for(
+        self, function_type: str, category: str
+    ) -> Mapping[str, Sequence[DuckDBFunctionDefinition]]:
+        type_bucket = self._index.get(function_type, {})
+        return type_bucket.get(category, {})
+
+
+class _DuckDBFunctionCall:
+    """Callable wrapper that renders a function invocation."""
+
+    def __init__(
+        self,
+        overloads: Sequence[DuckDBFunctionDefinition],
+        *,
+        return_category: str,
+    ) -> None:
+        self._overloads = overloads
+        self._return_category = return_category
+
+    def __call__(self, *operands: object) -> TypedExpression:
+        arguments = [_coerce_function_operand(operand) for operand in operands]
+        dependencies = _merge_dependencies(arguments)
+        overload = self._select_overload(len(arguments))
+        sql_name = _render_function_name(overload)
+        rendered_args = ", ".join(argument.render() for argument in arguments)
+        sql = f"{sql_name}({rendered_args})" if arguments else f"{sql_name}()"
+        return _construct_expression(
+            sql,
+            return_type=overload.return_type,
+            dependencies=dependencies,
+            category=self._return_category,
+        )
+
+    def _select_overload(self, argument_count: int) -> DuckDBFunctionDefinition:
+        for overload in self._overloads:
+            if overload.matches_arity(argument_count):
+                return overload
+        return self._overloads[0]
+
+
+class _FunctionAccessor:
+    """Surface area for functions in a given category."""
+
+    def __init__(
+        self,
+        functions: Mapping[str, Sequence[DuckDBFunctionDefinition]],
+        *,
+        return_category: str,
+    ) -> None:
+        self._functions = functions
+        self._return_category = return_category
+
+    def __getattr__(self, name: str) -> _DuckDBFunctionCall:
+        if name not in self._functions:
+            msg = f"Function '{name}' is not available in DuckDB catalog"
+            raise AttributeError(msg) from None
+        return _DuckDBFunctionCall(
+            self._functions[name], return_category=self._return_category
+        )
+
+    def __getitem__(self, name: str) -> _DuckDBFunctionCall:
+        if name not in self._functions:
+            raise KeyError(name)
+        return _DuckDBFunctionCall(
+            self._functions[name], return_category=self._return_category
+        )
+
+    def __dir__(self) -> Iterable[str]:
+        return sorted(name for name in self._functions if name.isidentifier())
+
+
+class _FunctionCategoryNamespace:
+    """Expose function categories grouped by return semantics."""
+
+    def __init__(self, catalog: DuckDBFunctionCatalog, function_type: str) -> None:
+        self._catalog = catalog
+        self._function_type = function_type
+
+    @property
+    @lru_cache(maxsize=None)
+    def Numeric(self) -> _FunctionAccessor:  # noqa: N802 - namespace attribute
+        return _FunctionAccessor(
+            self._catalog.functions_for(self._function_type, "numeric"),
+            return_category="numeric",
+        )
+
+    @property
+    @lru_cache(maxsize=None)
+    def Boolean(self) -> _FunctionAccessor:  # noqa: N802
+        return _FunctionAccessor(
+            self._catalog.functions_for(self._function_type, "boolean"),
+            return_category="boolean",
+        )
+
+    @property
+    @lru_cache(maxsize=None)
+    def Varchar(self) -> _FunctionAccessor:  # noqa: N802
+        return _FunctionAccessor(
+            self._catalog.functions_for(self._function_type, "varchar"),
+            return_category="varchar",
+        )
+
+    @property
+    @lru_cache(maxsize=None)
+    def Blob(self) -> _FunctionAccessor:  # noqa: N802
+        return _FunctionAccessor(
+            self._catalog.functions_for(self._function_type, "blob"),
+            return_category="blob",
+        )
+
+    @property
+    @lru_cache(maxsize=None)
+    def Generic(self) -> _FunctionAccessor:  # noqa: N802
+        return _FunctionAccessor(
+            self._catalog.functions_for(self._function_type, "generic"),
+            return_category="generic",
+        )
+
+
+class DuckDBFunctionNamespace:
+    """Lazy loader exposing DuckDB's scalar, aggregate, and window functions."""
+
+    def __init__(
+        self,
+        *,
+        loader: Callable[[], DuckDBFunctionCatalog] | None = None,
+    ) -> None:
+        self._loader = loader or DuckDBFunctionCatalog.load
+        self._catalog: DuckDBFunctionCatalog | None = None
+
+    def _catalogue(self) -> DuckDBFunctionCatalog:
+        if self._catalog is None:
+            self._catalog = self._loader()
+        return self._catalog
+
+    @property
+    def Scalar(self) -> _FunctionCategoryNamespace:  # noqa: N802
+        return _FunctionCategoryNamespace(self._catalogue(), "scalar")
+
+    @property
+    def Aggregate(self) -> _FunctionCategoryNamespace:  # noqa: N802
+        return _FunctionCategoryNamespace(self._catalogue(), "aggregate")
+
+    @property
+    def Window(self) -> _FunctionCategoryNamespace:  # noqa: N802
+        return _FunctionCategoryNamespace(self._catalogue(), "window")
+
+
+def _coerce_function_operand(value: object) -> TypedExpression:
+    if isinstance(value, TypedExpression):
+        return value
+    if isinstance(value, bool):
+        return BooleanExpression("TRUE" if value else "FALSE")
+    if isinstance(value, (int, float, Decimal)):
+        return NumericExpression.literal(value)
+    if isinstance(value, bytes):
+        return BlobExpression.literal(value)
+    if isinstance(value, str):
+        return GenericExpression(
+            _quote_identifier(value),
+            type_annotation="IDENTIFIER",
+            dependencies=(value,),
+        )
+    if value is None:
+        return GenericExpression("NULL")
+    msg = "DuckDB function arguments must be typed expressions or supported literals"
+    raise TypeError(msg)
+
+
+def _merge_dependencies(expressions: Iterable[TypedExpression]) -> frozenset[str]:
+    dependencies: set[str] = set()
+    for expression in expressions:
+        dependencies.update(expression.dependencies)
+    return frozenset(dependencies)
+
+
+def _render_function_name(definition: DuckDBFunctionDefinition) -> str:
+    schema = definition.schema_name
+    name = definition.function_name
+    if schema in ("main", "pg_catalog"):
+        return _quote_identifier(name) if name != name.lower() else name
+    return f"{_quote_identifier(schema)}.{_quote_identifier(name)}"
+
+
+def _construct_expression(
+    sql: str,
+    *,
+    return_type: str | None,
+    dependencies: frozenset[str],
+    category: str,
+) -> TypedExpression:
+    annotation = (return_type or "UNKNOWN").upper()
+    if category == "numeric":
+        return NumericExpression(sql, dependencies=dependencies, type_annotation=annotation)
+    if category == "boolean":
+        return BooleanExpression(sql, dependencies=dependencies, type_annotation=annotation)
+    if category == "varchar":
+        return VarcharExpression(sql, dependencies=dependencies, type_annotation=annotation)
+    if category == "blob":
+        return BlobExpression(sql, dependencies=dependencies, type_annotation=annotation)
+    return GenericExpression(sql, dependencies=dependencies, type_annotation=annotation)
+
+
+def _categorise_return_type(return_type: str | None) -> str:
+    if return_type is None:
+        return "generic"
+    normalized = return_type.upper()
+    if any(
+        normalized.startswith(prefix)
+        for prefix in (
+            "TINYINT",
+            "SMALLINT",
+            "INTEGER",
+            "BIGINT",
+            "HUGEINT",
+            "UTINYINT",
+            "USMALLINT",
+            "UINTEGER",
+            "UBIGINT",
+            "FLOAT",
+            "DOUBLE",
+            "DECIMAL",
+            "REAL",
+            "INTERVAL",
+        )
+    ):
+        return "numeric"
+    if normalized.startswith("BOOLEAN"):
+        return "boolean"
+    if any(
+        normalized.startswith(prefix)
+        for prefix in ("VARCHAR", "STRING", "TEXT", "JSON", "UUID")
+    ):
+        return "varchar"
+    if normalized.startswith("BLOB"):
+        return "blob"
+    return "generic"

--- a/tests/test_examples_pi_demo.py
+++ b/tests/test_examples_pi_demo.py
@@ -1,0 +1,57 @@
+"""Tests covering the Pi-themed typed expression demo."""
+
+import builtins
+
+import pytest
+
+from duckplus.examples import pi_demo
+
+
+def test_build_circle_expressions_uses_numeric_dependencies() -> None:
+    expressions = pi_demo.build_circle_expressions("r")
+    assert expressions.radius.render() == '"r"'
+    assert expressions.area.render() == '((3.141592653589793::DOUBLE * "r") * "r")'
+    assert expressions.area.dependencies == {"r"}
+    assert expressions.circumference.render() == '((3.141592653589793::DOUBLE * "r") * 2)'
+
+
+def test_project_circle_metrics_aliases_columns() -> None:
+    projection = pi_demo.project_circle_metrics("r")
+    rendered = [expression.render() for expression in projection]
+    assert rendered == [
+        '"r" AS "radius"',
+        '((3.141592653589793::DOUBLE * "r") * "r") AS "area"',
+        '((3.141592653589793::DOUBLE * "r") * 2) AS "circumference"',
+    ]
+
+
+def test_summarise_circle_metrics_renders_aggregations() -> None:
+    summary = pi_demo.summarise_circle_metrics("r")
+    rendered = [expression.render() for expression in summary]
+    assert rendered == [
+        'sum(((3.141592653589793::DOUBLE * "r") * "r")) AS "total_area"',
+        'sum(((3.141592653589793::DOUBLE * "r") * 2)) AS "total_circumference"',
+    ]
+
+
+def test_run_duckdb_demo_requires_duckdb(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_import(name: str, *args, **kwargs):  # type: ignore[no-untyped-def]
+        if name == "duckdb":
+            raise ModuleNotFoundError
+        return original_import(name, *args, **kwargs)
+
+    original_import = builtins.__import__
+    monkeypatch.setattr(builtins, "__import__", fake_import, raising=True)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        pi_demo.run_duckdb_demo()
+    assert "Install it with 'pip install duckdb'" in str(exc_info.value)
+
+
+def test_build_demo_queries_uses_projection_and_summary() -> None:
+    queries = pi_demo.build_demo_queries("r")
+    assert "projection" in queries
+    assert "summary" in queries
+    assert queries["projection"].startswith("SELECT ")
+    assert '"r" AS "radius"' in queries["projection"]
+    assert 'sum(((3.141592653589793::DOUBLE * "r") * 2))' in queries["summary"]

--- a/tests/test_typed_expression.py
+++ b/tests/test_typed_expression.py
@@ -1,0 +1,82 @@
+"""Unit tests for the typed expression sub-module."""
+
+import pytest
+
+from duckplus.typed import (
+    BooleanExpression,
+    DuckDBCatalogUnavailableError,
+    NumericExpression,
+    ducktype,
+)
+
+
+def test_numeric_column_carries_metadata() -> None:
+    expression = ducktype.Numeric("total")
+    assert isinstance(expression, NumericExpression)
+    assert expression.render() == '"total"'
+    assert expression.dependencies == {"total"}
+    assert expression.type_annotation == "NUMERIC"
+
+
+def test_numeric_aggregate_sum_uses_dependencies() -> None:
+    expression = ducktype.Numeric.Aggregate.sum("sales")
+    assert expression.render() == 'sum("sales")'
+    assert expression.dependencies == {"sales"}
+
+
+def test_varchar_equality_to_literal() -> None:
+    expression = ducktype.Varchar("customer") == "prime"
+    assert isinstance(expression, BooleanExpression)
+    assert expression.render() == "(\"customer\" = 'prime')"
+    assert expression.dependencies == {"customer"}
+
+
+def test_boolean_composition_with_literals() -> None:
+    predicate = ducktype.Boolean("is_active") & ducktype.Boolean.literal(True)
+    assert predicate.render() == '("is_active" AND TRUE)'
+    assert predicate.dependencies == {"is_active"}
+
+
+def test_numeric_arithmetic_and_aliasing() -> None:
+    expression = (ducktype.Numeric("subtotal") + 5).alias("order_total")
+    assert expression.render() == '("subtotal" + 5) AS "order_total"'
+    assert expression.dependencies == {"subtotal"}
+
+
+def test_numeric_operand_validation() -> None:
+    expression = ducktype.Numeric("price")
+    with pytest.raises(TypeError) as error_info:
+        _ = expression + "unexpected"
+    assert "numeric" in str(error_info.value).lower()
+
+
+@pytest.fixture(scope="module")
+def duckdb_functions_available() -> None:
+    try:
+        _ = ducktype.Functions.Aggregate.Numeric.sum
+    except DuckDBCatalogUnavailableError as error:
+        pytest.skip(str(error))
+
+
+@pytest.mark.usefixtures("duckdb_functions_available")
+def test_function_catalog_scalar_numeric_abs() -> None:
+    expression = ducktype.Functions.Scalar.Numeric.abs(ducktype.Numeric.literal(-5))
+    assert expression.render() == "abs(-5)"
+    assert expression.type_annotation.upper() in {"TINYINT", "SMALLINT", "INTEGER"}
+
+
+@pytest.mark.usefixtures("duckdb_functions_available")
+def test_function_catalog_boolean_namespace_handles_dependencies() -> None:
+    expression = ducktype.Functions.Scalar.Boolean.starts_with(
+        ducktype.Varchar("name"), ducktype.Varchar.literal("A")
+    )
+    assert expression.render() == "starts_with(\"name\", 'A')"
+    assert expression.dependencies == {"name"}
+    assert expression.type_annotation == "BOOLEAN"
+
+
+@pytest.mark.usefixtures("duckdb_functions_available")
+def test_function_catalog_aggregate_numeric_sum_alias() -> None:
+    expression = ducktype.Functions.Aggregate.Numeric.sum("revenue").alias("total")
+    assert expression.render() == 'sum("revenue") AS "total"'
+    assert expression.dependencies == {"revenue"}


### PR DESCRIPTION
## Summary
- add a `duckplus.examples.pi_demo` module with Pi-themed projection and aggregation helpers plus a runnable demo entry point
- document the demo workflow and type-checker feedback in `docs/pi_demo.md` while exercising it through dedicated unit tests
- allow importing `duckplus` without DuckDB installed and update TODO progress for the typed expression milestones

## Testing
- pytest
- mypy duckplus
- pylint duckplus
- uvx --help

------
https://chatgpt.com/codex/tasks/task_e_68eee1461728832290eec8e86e44ccf3